### PR TITLE
Add encrypted media support (MIP-04)

### DIFF
--- a/.cursor/rules/marmot.mdc
+++ b/.cursor/rules/marmot.mdc
@@ -1,0 +1,19 @@
+---
+description: Information about the Marmot protocol
+globs:
+alwaysApply: true
+---
+
+# Marmot Protocol
+
+This library is an implementation of the Marmot Protocol. It aims to implement the spec fully and accurately.
+
+## What is Marmot?
+
+Marmot is a protocol that brings together the MLS (Messaging Layer Security) Protocol and Nostr protocol to do secure messaging over Nostr's distributed relay network.
+
+You can find all the protocol specs in the /marmot workspace folder. Please ensure that all the code you are writing is on spec and always ask clarifying questions if part of the spec is unclear to you (we write the spec as well so we need to ensure that it's as clear and understandable as possible)
+
+## Running tests on optional features
+
+We have several feature flags in this repository. You often need to run test using feature flags. For example, the tests for `encrypted_media` need to be run with the `mip04` feature flag.

--- a/.cursor/rules/mls.mdc
+++ b/.cursor/rules/mls.mdc
@@ -1,0 +1,27 @@
+---
+description: MLS (Messaging Layer Security) Protocol Documentation and Resources
+globs:
+alwaysApply: true
+---
+
+# MLS Protocol Documentation and Resources
+
+This project implements the MLS (Messaging Layer Security) protocol on top of Nostr. Below are key resources and documentation that LLMs should reference when working on MLS-related code.
+
+## Official MLS Specifications
+
+- **RFC 9420**: The Messaging Layer Security (MLS) Protocol
+  - Official IETF specification: https://www.rfc-editor.org/rfc/rfc9420.html
+  - Local copy: [docs/mls/rfc9420.txt](mdc:docs/mls/rfc9420.txt)
+
+- **RFC 9750**: MLS Architecture
+  - MLS Architecture Overview: https://www.rfc-editor.org/rfc/rfc9750.html
+  - Local copy: [docs/mls/rfc9750.txt](mdc:docs/mls/rfc9750.txt)
+
+- **MLS Extensions**:
+    - https://www.ietf.org/archive/id/draft-ietf-mls-extensions-08.txt
+    - Local copy: [docs/mls/draft-ietf-mls-extentions-08.txt]
+
+## Marmot Protocol (MLS integration with Nostr protocol)
+
+- This repo is an implementation of the [Marmot protocol](https://github.com/parres-hq/marmot)

--- a/.cursor/rules/mls.mdc
+++ b/.cursor/rules/mls.mdc
@@ -20,7 +20,7 @@ This project implements the MLS (Messaging Layer Security) protocol on top of No
 
 - **MLS Extensions**:
     - https://www.ietf.org/archive/id/draft-ietf-mls-extensions-08.txt
-    - Local copy: [docs/mls/draft-ietf-mls-extentions-08.txt]
+    - Local copy: [docs/mls/draft-ietf-mls-extensions-08.txt](mdc:docs/mls/draft-ietf-mls-extensions-08.txt)
 
 ## Marmot Protocol (MLS integration with Nostr protocol)
 

--- a/.cursor/rules/nostr.mdc
+++ b/.cursor/rules/nostr.mdc
@@ -1,0 +1,29 @@
+---
+description: Information about the Nostr Protocol
+globs:
+alwaysApply: true
+---
+
+# Nostr Protocol References
+
+## NIP repo
+
+The nostr [NIPs repo](https://github.com/nostr-protocol/nips) is the official home of all nostr specs.
+
+## Nostrbook MCP
+
+You should have access to the Nostrbook MCP server that you can use to query the NIPs repo in a more structured way. If you don't have access to this you should prompt the user to install it with the following snippet:
+
+```json
+{
+  "mcpServers": {
+    "nostr": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@nostrbook/mcp@latest"
+      ]
+    }
+}
+```

--- a/.cursor/rules/nostr.mdc
+++ b/.cursor/rules/nostr.mdc
@@ -25,5 +25,6 @@ You should have access to the Nostrbook MCP server that you can use to query the
         "@nostrbook/mcp@latest"
       ]
     }
+  }
 }
 ```

--- a/.cursor/rules/nostr.mdc
+++ b/.cursor/rules/nostr.mdc
@@ -12,19 +12,4 @@ The nostr [NIPs repo](https://github.com/nostr-protocol/nips) is the official ho
 
 ## Nostrbook MCP
 
-You should have access to the Nostrbook MCP server that you can use to query the NIPs repo in a more structured way. If you don't have access to this you should prompt the user to install it with the following snippet:
-
-```json
-{
-  "mcpServers": {
-    "nostr": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@nostrbook/mcp@latest"
-      ]
-    }
-  }
-}
-```
+You should have access to the Nostrbook MCP server that you can use to query the NIPs repo in a more structured way. If you don't have access to this you should prompt the user to install it from https://nostrbook.dev/mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,57 @@ jobs:
     - name: Run full checks (Linux only)
       if: matrix.os == 'ubuntu-latest'
       run: just check
+
+  check-no-features:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Rust (stable)
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y pkg-config
+
+    - name: Check without optional features
+      run: cargo check --all-targets --no-default-features
+
+    - name: Build without optional features
+      run: cargo build --all-targets --no-default-features
+
+    - name: Test without optional features
+      run: cargo test --all-targets --no-default-features
+
+  check-mip04-feature:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Rust (stable)
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y pkg-config
+
+    - name: Check with mip04 feature only
+      run: cargo check --all-targets --no-default-features --features mip04
+
+    - name: Build with mip04 feature only
+      run: cargo build --all-targets --no-default-features --features mip04
+
+    - name: Test with mip04 feature only
+      run: cargo test --all-targets --no-default-features --features mip04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: native
-          - os: macos-latest
-            target: native
-          - os: macos-14
-            target: native
-    runs-on: ${{ matrix.os }}
+  format:
+    runs-on: ubuntu-latest
+    name: Format
 
     steps:
     - name: Checkout code
@@ -29,78 +21,115 @@ jobs:
     - name: Setup Rust (stable)
       uses: dtolnay/rust-toolchain@stable
       with:
-        components: rustfmt, clippy
+        components: rustfmt
+
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+
+  lint:
+    needs: format
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - name: "all-features"
+            flags: "--all-features"
+          - name: "no-features"
+            flags: "--no-default-features"
+          - name: "mip04-only"
+            flags: "--no-default-features --features mip04"
+
+    runs-on: ubuntu-latest
+    name: Lint (${{ matrix.features.name }})
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Rust (stable)
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: lint-${{ matrix.features.name }}
+
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y pkg-config
+
+    - name: Run clippy
+      run: cargo clippy --all-targets ${{ matrix.features.flags }} --no-deps -- -D warnings
+
+  docs:
+    needs: format
+    runs-on: ubuntu-latest
+    name: Documentation
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Rust (stable)
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y pkg-config
+
+    - name: Check documentation
+      run: cargo doc --all-features --no-deps --document-private-items
+      env:
+        RUSTDOCFLAGS: "-D warnings"
+
+  test:
+    needs: [format, lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-14]
+        features:
+          - name: "all-features"
+            flags: "--all-features"
+          - name: "no-features"
+            flags: "--no-default-features"
+          - name: "mip04-only"
+            flags: "--no-default-features --features mip04"
+
+    runs-on: ${{ matrix.os }}
+    name: Test (${{ matrix.os }}, ${{ matrix.features.name }})
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Rust (stable)
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Setup just
       uses: extractions/setup-just@v2
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ matrix.os }}-${{ matrix.features.name }}
 
     - name: Install system dependencies
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y pkg-config
 
     - name: Check
-      run: cargo check --all-targets --all-features
+      run: cargo check --all-targets ${{ matrix.features.flags }}
 
     - name: Build
-      run: cargo build --all-targets --all-features
+      run: cargo build --all-targets ${{ matrix.features.flags }}
 
-    - name: Run full checks (Linux only)
-      if: matrix.os == 'ubuntu-latest'
-      run: just check
+    - name: Test
+      run: cargo test --all-targets ${{ matrix.features.flags }}
 
-  check-no-features:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Rust (stable)
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-
-    - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y pkg-config
-
-    - name: Check without optional features
-      run: cargo check --all-targets --no-default-features
-
-    - name: Build without optional features
-      run: cargo build --all-targets --no-default-features
-
-    - name: Test without optional features
-      run: cargo test --all-targets --no-default-features
-
-  check-mip04-feature:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Rust (stable)
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-
-    - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y pkg-config
-
-    - name: Check with mip04 feature only
-      run: cargo check --all-targets --no-default-features --features mip04
-
-    - name: Build with mip04 feature only
-      run: cargo build --all-targets --no-default-features --features mip04
-
-    - name: Test with mip04 feature only
-      run: cargo test --all-targets --no-default-features --features mip04
+    - name: Test docs
+      if: matrix.features.name == 'all-features'
+      run: cargo test --doc ${{ matrix.features.flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,6 @@ jobs:
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
-      with:
-        key: lint-${{ matrix.features.name }}
 
     - name: Install system dependencies
       run: sudo apt-get update && sudo apt-get install -y pkg-config
@@ -108,9 +106,6 @@ jobs:
 
     - name: Setup Rust (stable)
       uses: dtolnay/rust-toolchain@stable
-
-    - name: Setup just
-      uses: extractions/setup-just@v2
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,10 +204,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "blurhash"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79769241dcd44edf79a732545e8b5cec84c247ac060f5252cd51885d093a8fc"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cbc"
@@ -220,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -270,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +317,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -392,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -523,6 +556,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,9 +582,19 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -586,7 +638,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -597,6 +649,16 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -627,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "hashlink"
@@ -892,13 +954,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.11.1"
+name = "image"
+version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -942,9 +1032,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -961,6 +1051,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,9 +1067,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libcrux-chacha20poly1305"
@@ -1209,7 +1308,12 @@ dependencies = [
 name = "mdk-core"
 version = "0.5.0"
 dependencies = [
+ "blurhash",
+ "chacha20poly1305",
  "hex",
+ "hkdf",
+ "image",
+ "kamadak-exif",
  "mdk-memory-storage",
  "mdk-sqlite-storage",
  "mdk-storage-traits",
@@ -1220,7 +1324,9 @@ dependencies = [
  "openmls_traits",
  "rand 0.9.2",
  "serde",
+ "sha2",
  "tempfile",
+ "thiserror 1.0.69",
  "tls_codec",
  "tokio",
  "tracing",
@@ -1272,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
@@ -1283,6 +1389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1295,6 +1402,22 @@ dependencies = [
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "moxcms"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd32fa8935aeadb8a8a6b6b351e40225570a37c43de67690383d87ef170cd08"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "nostr"
@@ -1583,6 +1706,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1804,21 @@ checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f9b339b02259ada5c0f4a389b7fb472f933aa17ce176fd2ad98f28bb401fde"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1818,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1830,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1981,24 +2132,34 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2007,14 +2168,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2061,6 +2223,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "siphasher"
@@ -2126,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
@@ -2188,11 +2356,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -2475,27 +2644,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2506,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -2520,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2530,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2543,22 +2712,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "winapi-util"
@@ -2677,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -2815,4 +2990,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
 ]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,399 @@
-# MDK - Marmot Development Kit
+# 🦫 MDK - Marmot Development Kit
+
+**A Rust implementation of the Marmot Protocol for secure, decentralized group messaging**
+
+![CI](https://github.com/parres-hq/mdk/actions/workflows/ci.yml/badge.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT)
+
+MDK is a Rust library that implements the [Marmot Protocol](https://github.com/parres-hq/marmot), bringing together the [MLS (Messaging Layer Security) Protocol](https://www.rfc-editor.org/rfc/rfc9420.html) with [Nostr's](https://github.com/nostr-protocol/nostr) decentralized network to enable secure group messaging without centralized servers.
+
+## 🚀 Features
+
+- **🔒 End-to-End Encryption**: Messages encrypted using the MLS protocol with forward secrecy and post-compromise security
+- **🌐 Decentralized**: Built on Nostr's distributed relay network - no central servers required
+- **👥 Group Messaging**: Secure group creation, member management, and messaging
+- **🔑 Key Management**: Automatic key package generation, rotation, and distribution
+- **💾 Flexible Storage**: Pluggable storage backends (in-memory, SQLite, custom)
+- **📱 Media Support**: Optional encrypted media sharing (images, files) with MIP-04
+- **🛡️ Metadata Protection**: Hides communication patterns and group membership
+- **⚡ Performance**: Efficient cryptographic operations and message processing
+
+## 📦 Architecture
+
+MDK is organized into several crates for modularity and flexibility:
+
+### Core Crates
+
+- **`mdk-core`**: Main library with MLS implementation and Nostr integration
+- **`mdk-storage-traits`**: Storage abstraction layer and trait definitions
+
+### Storage Providers
+
+- **`mdk-memory-storage`**: In-memory storage for testing and development
+- **`mdk-sqlite-storage`**: SQLite-based persistent storage with migrations
+
+## 🔐 OpenMLS Integration
+
+MDK is built on top of [OpenMLS](https://github.com/openmls/openmls), a robust Rust implementation of the MLS protocol. OpenMLS provides the cryptographic foundation while MDK adds Nostr-specific functionality and abstractions.
+
+### What OpenMLS Provides
+
+- **MLS Protocol Implementation**: Full RFC 9420 compliance with all cryptographic operations
+- **Group Management**: Creating, updating, and managing MLS groups
+- **Key Management**: Automatic key rotation, forward secrecy, and post-compromise security
+- **Message Processing**: Encryption, decryption, and authentication of group messages
+- **Extensibility**: Support for MLS extensions (which MDK uses for Nostr integration)
+
+### How MDK Uses OpenMLS
+
+```rust
+use openmls::prelude::*;
+use openmls_rust_crypto::RustCrypto;
+
+// MDK wraps OpenMLS with Nostr-specific functionality
+pub struct MdkProvider<Storage> {
+    crypto: RustCrypto,           // OpenMLS crypto provider
+    storage: Storage,             // Custom storage abstraction
+}
+
+impl<Storage> OpenMlsProvider for MdkProvider<Storage> {
+    type CryptoProvider = RustCrypto;
+    type RandProvider = RustCrypto;
+    type StorageProvider = Storage::OpenMlsStorageProvider;
+    // ... implementation details
+}
+```
+
+### Key OpenMLS Components in MDK
+
+- **`MlsGroup`**: Core group management (wrapped by MDK's group handling)
+- **`KeyPackage`**: Identity and key distribution (published as Nostr events)
+- **`Welcome`**: Group invitation messages (sent via Nostr's gift-wrap)
+- **`MlsMessageOut`**: Encrypted group messages (published as Nostr events)
+- **`Credential`**: Identity verification (integrated with Nostr keys)
+
+### Ciphersuite and Extensions
+
+MDK configures OpenMLS with specific settings for Nostr compatibility:
+
+```rust
+// Default ciphersuite for all MDK groups
+const DEFAULT_CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+// Required extensions for Nostr integration
+const REQUIRED_EXTENSIONS: &[ExtensionType] = &[
+    ExtensionType::ApplicationId,
+    ExtensionType::RatchetTree,
+    ExtensionType::RequiredCapabilities,
+    ExtensionType::Unknown(0xF2EE), // Marmot Group Data Extension
+];
+```
+
+This ensures all MDK groups use compatible cryptography and include necessary Nostr-specific metadata.
+
+## 🔧 Installation
+
+Add MDK to your `Cargo.toml`:
+
+```toml
+[dependencies]
+mdk-core = "0.5.0"
+mdk-memory-storage = "0.5.0"  # For in-memory storage
+# OR
+mdk-sqlite-storage = "0.5.0"  # For persistent SQLite storage
+```
+
+### Feature Flags
+
+- **`mip04`**: Enable encrypted media support (images, files)
+
+```toml
+[dependencies]
+mdk-core = { version = "0.5.0", features = ["mip04"] }
+```
+
+## 🚀 Quick Start
+
+Here's a basic example of creating a group and sending messages:
+
+```rust
+use mdk_core::prelude::*;
+use mdk_memory_storage::MdkMemoryStorage;
+use nostr::{Keys, Kind, RelayUrl};
+use nostr::event::builder::EventBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Generate identities
+    let alice_keys = Keys::generate();
+    let bob_keys = Keys::generate();
+
+    // Create MDK instances
+    let alice_mdk = MDK::new(MdkMemoryStorage::default());
+    let bob_mdk = MDK::new(MdkMemoryStorage::default());
+
+    let relay_url = RelayUrl::parse("wss://relay.example.com")?;
+
+    // Bob creates a key package
+    let (bob_key_package, tags) = bob_mdk
+        .create_key_package_for_event(&bob_keys.public_key(), [relay_url.clone()])?;
+
+    let bob_key_package_event = EventBuilder::new(Kind::MlsKeyPackage, bob_key_package)
+        .tags(tags)
+        .build(bob_keys.public_key())
+        .sign(&bob_keys)
+        .await?;
+
+    // Alice creates a group with Bob
+    let config = NostrGroupConfigData::new(
+        "Alice & Bob".to_string(),
+        "Private chat".to_string(),
+        None, // image_hash
+        None, // image_key
+        None, // image_nonce
+        vec![relay_url],
+        vec![alice_keys.public_key(), bob_keys.public_key()],
+    );
+
+    let group_result = alice_mdk.create_group(
+        &alice_keys.public_key(),
+        vec![bob_key_package_event],
+        config,
+    )?;
+
+    // Bob processes the welcome message
+    let welcome_rumor = &group_result.welcome_rumors[0];
+    bob_mdk.process_welcome(&nostr::EventId::all_zeros(), welcome_rumor)?;
+
+    let welcomes = bob_mdk.get_pending_welcomes()?;
+    bob_mdk.accept_welcome(&welcomes[0])?;
+
+    // Alice sends a message
+    let message_rumor = EventBuilder::new(Kind::Custom(9), "Hello Bob!")
+        .build(alice_keys.public_key());
+
+    let message_event = alice_mdk.create_message(
+        &group_result.group.mls_group_id,
+        message_rumor
+    )?;
+
+    // Bob processes the message
+    bob_mdk.process_message(&message_event)?;
+
+    println!("Message sent and received successfully!");
+    Ok(())
+}
+```
+
+## 💾 Storage Options
+
+### In-Memory Storage (Development)
+
+```rust
+use mdk_memory_storage::MdkMemoryStorage;
+
+let mdk = MDK::new(MdkMemoryStorage::default());
+```
+
+### SQLite Storage (Production)
+
+```rust
+use mdk_sqlite_storage::MdkSqliteStorage;
+
+let storage = MdkSqliteStorage::new("path/to/database.db").await?;
+let mdk = MDK::new(storage);
+```
+
+### Custom Storage
+
+Implement the `MdkStorageProvider` trait for custom storage backends:
+
+```rust
+use mdk_storage_traits::MdkStorageProvider;
+
+struct MyCustomStorage;
+
+impl MdkStorageProvider for MyCustomStorage {
+    // Implement required methods
+}
+```
+
+## 🖼️ Encrypted Media (MIP-04)
+
+Enable the `mip04` feature for encrypted media support:
+
+```rust
+#[cfg(feature = "mip04")]
+use mdk_core::encrypted_media::*;
+
+// Encrypt and upload media
+let media_manager = EncryptedMediaManager::new();
+let encrypted_media = media_manager.encrypt_image(&image_bytes)?;
+```
+
+## 🔍 Examples
+
+Check out the [`examples/`](crates/mdk-core/examples/) directory for complete working examples:
+
+- [`mls_memory.rs`](crates/mdk-core/examples/mls_memory.rs): Full group messaging workflow with in-memory storage
+- [`mls_sqlite.rs`](crates/mdk-core/examples/mls_sqlite.rs): Persistent storage example with SQLite
+
+Run examples with:
+
+```bash
+cargo run --example mls_memory
+cargo run --example mls_sqlite
+```
+
+## 🧪 Testing
+
+We recommend using [just](https://github.com/casey/just) for running tests and development tasks:
+
+```bash
+# Run all tests with all features (recommended)
+just test
+
+# Run tests without optional features
+just test-no-features
+
+# Run tests with only mip04 feature
+just test-mip04
+
+# Run all test combinations (like CI)
+just test-all
+```
+
+You can also use cargo directly:
+
+```bash
+# Run all tests
+cargo test
+
+# Run tests with encrypted media support
+cargo test --features mip04
+
+# Run tests for specific crate
+cargo test -p mdk-core
+```
+
+## 📚 Documentation
+
+- **API Documentation**: [docs.rs/mdk-core](https://docs.rs/mdk-core)
+- **Marmot Protocol**: [github.com/parres-hq/marmot](https://github.com/parres-hq/marmot)
+- **MLS Specification**: [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html)
+- **OpenMLS Library**: [github.com/openmls/openmls](https://github.com/openmls/openmls) - The MLS implementation we build upon
+- **Nostr Protocol**: [github.com/nostr-protocol/nostr](https://github.com/nostr-protocol/nostr)
+
+## 🛠️ Development
+
+### Prerequisites
+
+- Rust 1.85.0 or later
+- SQLite (for sqlite storage tests)
+- [just](https://github.com/casey/just) (recommended for development)
+
+### Building
+
+```bash
+git clone https://github.com/parres-hq/mdk.git
+cd mdk
+cargo build
+```
+
+### Development Commands (justfile)
+
+We use [just](https://github.com/casey/just) as a command runner for development tasks. Install it with:
+
+```bash
+# macOS
+brew install just
+
+# Other platforms: https://github.com/casey/just#installation
+```
+
+Available commands:
+
+```bash
+# List all available commands
+just
+
+# Testing
+just test              # Run tests with all features
+just test-no-features  # Run tests without optional features
+just test-mip04        # Run tests with only mip04 feature
+just test-all          # Run all test combinations (like CI)
+
+# Code Quality
+just lint              # Run clippy with all features
+just lint-no-features  # Run clippy without optional features
+just lint-mip04        # Run clippy with only mip04 feature
+just lint-all          # Run clippy for all feature combinations
+just fmt               # Check code formatting
+just docs              # Check documentation
+
+# Comprehensive Checks
+just check             # Run all checks (like CI)
+just check-full        # Full comprehensive check with all feature combinations
+```
+
+The justfile ensures consistent testing across different feature combinations, which is especially important for optional features like `mip04`.
+
+## 🤝 Contributing
+
+We welcome contributions! Please see our [contributing guidelines](CONTRIBUTING.md) and:
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests
+5. Run the full test suite: `just check-full`
+6. Submit a pull request
+
+**Before submitting a PR**, ensure all checks pass:
+
+```bash
+# Run comprehensive checks (recommended)
+just check-full
+
+# Or run individual checks
+just fmt       # Check formatting
+just lint-all  # Check all clippy combinations
+just test-all  # Run all test combinations
+just docs      # Check documentation
+```
+
+### Security
+
+For security issues, please email **j@jeffg.me** instead of opening a public issue.
+
+## ⚠️ Status
+
+**MDK is currently in ALPHA status.** While functional, the API may change in breaking ways. Use in production is not recommended until the library reaches stable status.
+
+Current implementations are suitable for:
+- Research and development
+- Proof-of-concept applications
+- Contributing to protocol development
+- Educational purposes
+
+## 📄 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## 🙏 Acknowledgments
+
+- **[OpenMLS](https://github.com/openmls/openmls)**: The robust MLS protocol implementation that powers MDK's cryptographic operations
+- **[rust-nostr](https://github.com/rust-nostr/nostr)**: Comprehensive Nostr protocol support and event handling
+- **[OpenMLS Team](https://github.com/openmls)**: For their excellent work on MLS protocol implementation and storage abstractions
+- **MLS Working Group**: For developing the MLS specification (RFC 9420)
+- **Nostr Community**: For creating a truly decentralized communication protocol
+
+## 🔗 Related Projects
+
+- [whitenoise](https://github.com/parres-hq/whitenoise): Full-featured messenger using MDK
+- [whitenoise_flutter](https://github.com/parres-hq/whitenoise_flutter): Flutter app using whitenoise
+- [marmot-ts](https://github.com/parres-hq/marmot-ts): TypeScript implementation of Marmot
+
+---
+
+Built with ❤️ for a more private and decentralized future.

--- a/crates/mdk-core/Cargo.toml
+++ b/crates/mdk-core/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["nostr", "mls", "openmls"]
 
 [features]
 default = []
-mip04 = ["dep:image", "dep:blurhash", "dep:chacha20poly1305", "dep:hkdf", "dep:sha2", "dep:kamadak-exif"]
+mip04 = ["dep:image", "dep:blurhash", "dep:kamadak-exif"]
 
 [dependencies]
 hex = { workspace = true, features = ["std"] }
@@ -26,15 +26,17 @@ openmls_traits = { version = "0.4.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tls_codec = "0.4"
 tracing = { workspace = true, features = ["std"] }
+thiserror = "1.0"
 
-# Optional dependencies for encrypted-media feature
+# Crypto dependencies for MIP-01 (group image encryption) - mandatory
+chacha20poly1305 = "0.10"
+hkdf = "0.12"
+sha2 = "0.10"
+
+# Optional dependencies for MIP-04 (encrypted media) feature
 image = { version = "0.25", optional = true, default-features = false, features = ["jpeg", "png", "webp", "gif"] }
 blurhash = { version = "0.2", optional = true }
-chacha20poly1305 = { version = "0.10", optional = true }
-hkdf = { version = "0.12", optional = true }
-sha2 = { version = "0.10", optional = true }
 kamadak-exif = { version = "0.6", optional = true }
-thiserror = "1.0"
 
 [dev-dependencies]
 mdk-storage-traits = { workspace = true, features = ["test-utils"] }

--- a/crates/mdk-core/Cargo.toml
+++ b/crates/mdk-core/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 rust-version = "1.85.0"
 keywords = ["nostr", "mls", "openmls"]
 
+[features]
+default = []
+mip04 = ["dep:image", "dep:blurhash", "dep:chacha20poly1305", "dep:hkdf", "dep:sha2", "dep:kamadak-exif"]
+
 [dependencies]
 hex = { workspace = true, features = ["std"] }
 nostr = { workspace = true, features = ["std", "nip44"] }
@@ -22,6 +26,15 @@ openmls_traits = { version = "0.4.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tls_codec = "0.4"
 tracing = { workspace = true, features = ["std"] }
+
+# Optional dependencies for encrypted-media feature
+image = { version = "0.25", optional = true, default-features = false, features = ["jpeg", "png", "webp", "gif"] }
+blurhash = { version = "0.2", optional = true }
+chacha20poly1305 = { version = "0.10", optional = true }
+hkdf = { version = "0.12", optional = true }
+sha2 = { version = "0.10", optional = true }
+kamadak-exif = { version = "0.6", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 mdk-storage-traits = { workspace = true, features = ["test-utils"] }

--- a/crates/mdk-core/src/encrypted_media/crypto.rs
+++ b/crates/mdk-core/src/encrypted_media/crypto.rs
@@ -206,26 +206,22 @@ mod tests {
     }
 
     #[test]
-    fn test_encryption_decryption_roundtrip() {
+    fn test_errors_without_group() {
         let mdk = create_test_mdk();
         let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
 
         let original_data =
             b"This is test image data that should be encrypted and decrypted properly";
         let mime_type = "image/jpeg";
-        let _filename = "test.jpg";
-
-        // Test the encryption/decryption flow
-        // For this test, we'll focus on the internal encryption/decryption methods
-        // since the full encrypt_for_upload requires a proper MLS group setup
+        let filename = "test.jpg";
 
         let original_hash: [u8; 32] = Sha256::digest(original_data).into();
 
         // Test key and nonce derivation (these will fail without a proper group, but we can test the logic)
         let key_result =
-            derive_encryption_key(&mdk, &group_id, &original_hash, mime_type, _filename);
+            derive_encryption_key(&mdk, &group_id, &original_hash, mime_type, filename);
         let nonce_result =
-            derive_encryption_nonce(&mdk, &group_id, &original_hash, mime_type, _filename);
+            derive_encryption_nonce(&mdk, &group_id, &original_hash, mime_type, filename);
 
         // These should fail gracefully since we don't have a real MLS group
         assert!(key_result.is_err());

--- a/crates/mdk-core/src/encrypted_media/crypto.rs
+++ b/crates/mdk-core/src/encrypted_media/crypto.rs
@@ -1,0 +1,465 @@
+//! Cryptographic operations for encrypted media
+//!
+//! This module handles all encryption and decryption operations for media files,
+//! including key derivation, nonce generation, and ChaCha20-Poly1305 AEAD operations
+//! according to the Marmot protocol specification.
+
+use chacha20poly1305::{
+    aead::{Aead, KeyInit},
+    ChaCha20Poly1305, Nonce,
+};
+use hkdf::Hkdf;
+use sha2::Sha256;
+
+use crate::encrypted_media::types::EncryptedMediaError;
+use crate::{GroupId, MDK};
+use mdk_storage_traits::MdkStorageProvider;
+
+/// Scheme label for MIP-04 version 1 encryption to provide domain separation
+/// and prevent cross-version collisions
+const SCHEME_LABEL: &[u8] = b"mip04-v1";
+
+/// Build HKDF context for key/nonce derivation with scheme label for domain separation
+fn build_hkdf_context(
+    file_hash: &[u8; 32],
+    mime_type: &str,
+    filename: &str,
+    suffix: &[u8],
+) -> Vec<u8> {
+    let mut context = Vec::new();
+    context.extend_from_slice(SCHEME_LABEL);
+    context.push(0x00);
+    context.extend_from_slice(file_hash);
+    context.push(0x00);
+    context.extend_from_slice(mime_type.as_bytes());
+    context.push(0x00);
+    context.extend_from_slice(filename.as_bytes());
+    context.push(0x00);
+    context.extend_from_slice(suffix);
+    context
+}
+
+/// Build AAD (Associated Authenticated Data) for AEAD encryption with scheme label
+fn build_aad(file_hash: &[u8; 32], mime_type: &str, filename: &str) -> Vec<u8> {
+    let mut aad = Vec::new();
+    aad.extend_from_slice(SCHEME_LABEL);
+    aad.push(0x00);
+    aad.extend_from_slice(file_hash);
+    aad.push(0x00);
+    aad.extend_from_slice(mime_type.as_bytes());
+    aad.push(0x00);
+    aad.extend_from_slice(filename.as_bytes());
+    aad
+}
+
+/// Derive encryption key from MLS group secret according to Marmot protocol specification
+///
+/// As specified in Marmot protocol 04.md, the encryption key is derived using:
+/// file_key = HKDF-Expand(exporter_secret, SCHEME_LABEL || 0x00 || file_hash_bytes || 0x00 || mime_type_bytes || 0x00 || filename_bytes || 0x00 || "key", 32)
+pub fn derive_encryption_key<Storage>(
+    mdk: &MDK<Storage>,
+    group_id: &GroupId,
+    original_hash: &[u8; 32],
+    mime_type: &str,
+    filename: &str,
+) -> Result<[u8; 32], EncryptedMediaError>
+where
+    Storage: MdkStorageProvider,
+{
+    // Get the group's exporter secret
+    let exporter_secret = mdk
+        .exporter_secret(group_id)
+        .map_err(|_| EncryptedMediaError::GroupNotFound)?;
+
+    // Create context as specified in Marmot protocol 04.md:
+    // SCHEME_LABEL || 0x00 || file_hash_bytes || 0x00 || mime_type_bytes || 0x00 || filename_bytes || 0x00 || "key"
+    let context = build_hkdf_context(original_hash, mime_type, filename, b"key");
+
+    // Use HKDF to derive encryption key with context
+    let hk = Hkdf::<Sha256>::new(None, &exporter_secret.secret);
+
+    let mut key = [0u8; 32];
+    hk.expand(&context, &mut key)
+        .map_err(|e| EncryptedMediaError::EncryptionFailed {
+            reason: format!("Key derivation failed: {}", e),
+        })?;
+
+    Ok(key)
+}
+
+/// Derive encryption nonce from context according to Marmot protocol specification
+///
+/// As specified in Marmot protocol 04.md, the encryption nonce is derived using:
+/// nonce = HKDF-Expand(exporter_secret, SCHEME_LABEL || 0x00 || file_hash_bytes || 0x00 || mime_type_bytes || 0x00 || filename_bytes || 0x00 || "nonce", 12)
+///
+/// This ensures the nonce is deterministic and can be reproduced for decryption
+/// without needing to store it separately.
+pub fn derive_encryption_nonce<Storage>(
+    mdk: &MDK<Storage>,
+    group_id: &GroupId,
+    original_hash: &[u8; 32],
+    mime_type: &str,
+    filename: &str,
+) -> Result<[u8; 12], EncryptedMediaError>
+where
+    Storage: MdkStorageProvider,
+{
+    // Get the group's exporter secret
+    let exporter_secret = mdk
+        .exporter_secret(group_id)
+        .map_err(|_| EncryptedMediaError::GroupNotFound)?;
+
+    // Create context as specified in Marmot protocol 04.md:
+    // SCHEME_LABEL || 0x00 || file_hash_bytes || 0x00 || mime_type_bytes || 0x00 || filename_bytes || 0x00 || "nonce"
+    let context = build_hkdf_context(original_hash, mime_type, filename, b"nonce");
+
+    // Use HKDF to derive nonce with context
+    let hk = Hkdf::<Sha256>::new(None, &exporter_secret.secret);
+
+    let mut nonce = [0u8; 12];
+    hk.expand(&context, &mut nonce)
+        .map_err(|e| EncryptedMediaError::EncryptionFailed {
+            reason: format!("Nonce derivation failed: {}", e),
+        })?;
+
+    Ok(nonce)
+}
+
+/// Encrypt data using ChaCha20-Poly1305 AEAD with Associated Authenticated Data
+///
+/// As specified in MIP-04, the AAD includes:
+/// aad = SCHEME_LABEL || 0x00 || file_hash_bytes || 0x00 || mime_type_bytes || 0x00 || filename_bytes
+pub fn encrypt_data_with_aad(
+    data: &[u8],
+    key: &[u8; 32],
+    nonce: &[u8; 12],
+    file_hash: &[u8; 32],
+    mime_type: &str,
+    filename: &str,
+) -> Result<Vec<u8>, EncryptedMediaError> {
+    let cipher = ChaCha20Poly1305::new_from_slice(key).map_err(|e| {
+        EncryptedMediaError::EncryptionFailed {
+            reason: format!("Failed to create cipher: {}", e),
+        }
+    })?;
+
+    let nonce = Nonce::from_slice(nonce);
+
+    let aad = build_aad(file_hash, mime_type, filename);
+
+    cipher
+        .encrypt(
+            nonce,
+            chacha20poly1305::aead::Payload {
+                msg: data,
+                aad: &aad,
+            },
+        )
+        .map_err(|e| EncryptedMediaError::EncryptionFailed {
+            reason: format!("Encryption failed: {}", e),
+        })
+}
+
+/// Decrypt data using ChaCha20-Poly1305 AEAD with Associated Authenticated Data
+///
+/// As specified in MIP-04, the AAD includes:
+/// aad = SCHEME_LABEL || 0x00 || file_hash_bytes || 0x00 || mime_type_bytes || 0x00 || filename_bytes
+pub fn decrypt_data_with_aad(
+    encrypted_data: &[u8],
+    key: &[u8; 32],
+    nonce: &[u8; 12],
+    file_hash: &[u8; 32],
+    mime_type: &str,
+    filename: &str,
+) -> Result<Vec<u8>, EncryptedMediaError> {
+    let cipher = ChaCha20Poly1305::new_from_slice(key).map_err(|e| {
+        EncryptedMediaError::DecryptionFailed {
+            reason: format!("Failed to create cipher: {}", e),
+        }
+    })?;
+
+    let nonce = Nonce::from_slice(nonce);
+
+    let aad = build_aad(file_hash, mime_type, filename);
+
+    cipher
+        .decrypt(
+            nonce,
+            chacha20poly1305::aead::Payload {
+                msg: encrypted_data,
+                aad: &aad,
+            },
+        )
+        .map_err(|e| EncryptedMediaError::DecryptionFailed {
+            reason: format!("Decryption failed: {}", e),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdk_memory_storage::MdkMemoryStorage;
+    use sha2::Digest;
+
+    fn create_test_mdk() -> MDK<MdkMemoryStorage> {
+        MDK::new(MdkMemoryStorage::default())
+    }
+
+    #[test]
+    fn test_encryption_decryption_roundtrip() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+
+        let original_data =
+            b"This is test image data that should be encrypted and decrypted properly";
+        let mime_type = "image/jpeg";
+        let _filename = "test.jpg";
+
+        // Test the encryption/decryption flow
+        // For this test, we'll focus on the internal encryption/decryption methods
+        // since the full encrypt_for_upload requires a proper MLS group setup
+
+        let original_hash: [u8; 32] = Sha256::digest(original_data).into();
+
+        // Test key and nonce derivation (these will fail without a proper group, but we can test the logic)
+        let key_result =
+            derive_encryption_key(&mdk, &group_id, &original_hash, mime_type, _filename);
+        let nonce_result =
+            derive_encryption_nonce(&mdk, &group_id, &original_hash, mime_type, _filename);
+
+        // These should fail gracefully since we don't have a real MLS group
+        assert!(key_result.is_err());
+        assert!(nonce_result.is_err());
+
+        // Verify the error is the expected "GroupNotFound" error
+        if let Err(EncryptedMediaError::GroupNotFound) = key_result {
+            // Expected behavior
+        } else {
+            panic!("Expected GroupNotFound error for key derivation");
+        }
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_with_known_key() {
+        // Test encryption/decryption with a known key and nonce
+        let key = [0x42u8; 32];
+        let nonce = [0x24u8; 12];
+        let original_data = b"Hello, encrypted world!";
+        let file_hash = [0x01u8; 32];
+        let mime_type = "image/jpeg";
+        let filename = "test.jpg";
+
+        // Encrypt the data
+        let encrypted_result =
+            encrypt_data_with_aad(original_data, &key, &nonce, &file_hash, mime_type, filename);
+        assert!(encrypted_result.is_ok());
+        let encrypted_data = encrypted_result.unwrap();
+
+        // Verify encrypted data is different from original
+        assert_ne!(encrypted_data.as_slice(), original_data);
+        assert!(encrypted_data.len() > original_data.len()); // Should include auth tag
+
+        // Decrypt the data
+        let decrypted_result = decrypt_data_with_aad(
+            &encrypted_data,
+            &key,
+            &nonce,
+            &file_hash,
+            mime_type,
+            filename,
+        );
+        assert!(decrypted_result.is_ok());
+        let decrypted_data = decrypted_result.unwrap();
+
+        // Verify decrypted data matches original
+        assert_eq!(decrypted_data.as_slice(), original_data);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_with_different_aad() {
+        // Test that changing AAD components causes decryption to fail
+        let key = [0x42u8; 32];
+        let nonce = [0x24u8; 12];
+        let original_data = b"Hello, encrypted world!";
+        let file_hash = [0x01u8; 32];
+        let mime_type = "image/jpeg";
+        let filename = "test.jpg";
+
+        // Encrypt with original parameters
+        let encrypted_data =
+            encrypt_data_with_aad(original_data, &key, &nonce, &file_hash, mime_type, filename)
+                .unwrap();
+
+        // Try to decrypt with different file hash (should fail)
+        let different_hash = [0x02u8; 32];
+        let result = decrypt_data_with_aad(
+            &encrypted_data,
+            &key,
+            &nonce,
+            &different_hash,
+            mime_type,
+            filename,
+        );
+        assert!(result.is_err());
+
+        // Try to decrypt with different MIME type (should fail)
+        let result = decrypt_data_with_aad(
+            &encrypted_data,
+            &key,
+            &nonce,
+            &file_hash,
+            "image/png",
+            filename,
+        );
+        assert!(result.is_err());
+
+        // Try to decrypt with different filename (should fail)
+        let result = decrypt_data_with_aad(
+            &encrypted_data,
+            &key,
+            &nonce,
+            &file_hash,
+            mime_type,
+            "different.jpg",
+        );
+        assert!(result.is_err());
+
+        // Decrypt with correct parameters (should succeed)
+        let result = decrypt_data_with_aad(
+            &encrypted_data,
+            &key,
+            &nonce,
+            &file_hash,
+            mime_type,
+            filename,
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_slice(), original_data);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_with_wrong_key() {
+        // Test that using wrong key causes decryption to fail
+        let key = [0x42u8; 32];
+        let wrong_key = [0x43u8; 32];
+        let nonce = [0x24u8; 12];
+        let original_data = b"Hello, encrypted world!";
+        let file_hash = [0x01u8; 32];
+        let mime_type = "image/jpeg";
+        let filename = "test.jpg";
+
+        // Encrypt with original key
+        let encrypted_data =
+            encrypt_data_with_aad(original_data, &key, &nonce, &file_hash, mime_type, filename)
+                .unwrap();
+
+        // Try to decrypt with wrong key (should fail)
+        let result = decrypt_data_with_aad(
+            &encrypted_data,
+            &wrong_key,
+            &nonce,
+            &file_hash,
+            mime_type,
+            filename,
+        );
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::DecryptionFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_with_wrong_nonce() {
+        // Test that using wrong nonce causes decryption to fail
+        let key = [0x42u8; 32];
+        let nonce = [0x24u8; 12];
+        let wrong_nonce = [0x25u8; 12];
+        let original_data = b"Hello, encrypted world!";
+        let file_hash = [0x01u8; 32];
+        let mime_type = "image/jpeg";
+        let filename = "test.jpg";
+
+        // Encrypt with original nonce
+        let encrypted_data =
+            encrypt_data_with_aad(original_data, &key, &nonce, &file_hash, mime_type, filename)
+                .unwrap();
+
+        // Try to decrypt with wrong nonce (should fail)
+        let result = decrypt_data_with_aad(
+            &encrypted_data,
+            &key,
+            &wrong_nonce,
+            &file_hash,
+            mime_type,
+            filename,
+        );
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::DecryptionFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn test_encrypt_empty_data() {
+        // Test encryption of empty data
+        let key = [0x42u8; 32];
+        let nonce = [0x24u8; 12];
+        let empty_data = b"";
+        let file_hash = [0x01u8; 32];
+        let mime_type = "image/jpeg";
+        let filename = "empty.jpg";
+
+        // Encrypt empty data
+        let encrypted_result =
+            encrypt_data_with_aad(empty_data, &key, &nonce, &file_hash, mime_type, filename);
+        assert!(encrypted_result.is_ok());
+        let encrypted_data = encrypted_result.unwrap();
+
+        // Should still have auth tag even for empty data
+        assert!(!encrypted_data.is_empty());
+
+        // Decrypt and verify
+        let decrypted_result = decrypt_data_with_aad(
+            &encrypted_data,
+            &key,
+            &nonce,
+            &file_hash,
+            mime_type,
+            filename,
+        );
+        assert!(decrypted_result.is_ok());
+        assert_eq!(decrypted_result.unwrap().as_slice(), empty_data);
+    }
+
+    #[test]
+    fn test_aad_construction() {
+        // Test that AAD is constructed correctly by verifying different components
+        // cause different encrypted outputs
+        let key = [0x42u8; 32];
+        let nonce = [0x24u8; 12];
+        let data = b"test data";
+        let file_hash = [0x01u8; 32];
+
+        // Encrypt with first set of AAD components
+        let encrypted1 =
+            encrypt_data_with_aad(data, &key, &nonce, &file_hash, "image/jpeg", "photo.jpg")
+                .unwrap();
+
+        // Encrypt with different MIME type
+        let encrypted2 =
+            encrypt_data_with_aad(data, &key, &nonce, &file_hash, "image/png", "photo.jpg")
+                .unwrap();
+
+        // Encrypt with different filename
+        let encrypted3 =
+            encrypt_data_with_aad(data, &key, &nonce, &file_hash, "image/jpeg", "image.jpg")
+                .unwrap();
+
+        // All encrypted outputs should be different due to different AAD
+        assert_ne!(encrypted1, encrypted2);
+        assert_ne!(encrypted1, encrypted3);
+        assert_ne!(encrypted2, encrypted3);
+    }
+}

--- a/crates/mdk-core/src/encrypted_media/manager.rs
+++ b/crates/mdk-core/src/encrypted_media/manager.rs
@@ -1,0 +1,838 @@
+//! Main encrypted media manager
+//!
+//! This module contains the EncryptedMediaManager struct which provides the
+//! high-level API for encrypting, decrypting, and managing encrypted media
+//! within MLS groups on Nostr.
+
+use nostr::{Tag as NostrTag, TagKind};
+use sha2::{Digest, Sha256};
+
+use crate::encrypted_media::crypto::{
+    decrypt_data_with_aad, derive_encryption_key, derive_encryption_nonce, encrypt_data_with_aad,
+};
+use crate::encrypted_media::metadata::extract_and_process_metadata;
+use crate::encrypted_media::types::{
+    EncryptedMediaError, EncryptedMediaUpload, MediaProcessingOptions, MediaReference,
+};
+use crate::encrypted_media::validation::{validate_inputs, validate_mime_type};
+use crate::{GroupId, MDK};
+use mdk_storage_traits::MdkStorageProvider;
+
+/// Manager for encrypted media operations
+pub struct EncryptedMediaManager<'a, Storage>
+where
+    Storage: MdkStorageProvider,
+{
+    mdk: &'a MDK<Storage>,
+    group_id: GroupId,
+}
+
+impl<'a, Storage> EncryptedMediaManager<'a, Storage>
+where
+    Storage: MdkStorageProvider,
+{
+    /// Create a new encrypted media manager for a specific group
+    pub fn new(mdk: &'a MDK<Storage>, group_id: GroupId) -> Self {
+        Self { mdk, group_id }
+    }
+
+    /// Encrypt media for upload with default options
+    ///
+    /// # Parameters
+    /// - `data`: The raw media file data
+    /// - `mime_type`: MIME type of the media (e.g., "image/jpeg")
+    /// - `filename`: Original filename (required for AAD in encryption)
+    pub fn encrypt_for_upload(
+        &self,
+        data: &[u8],
+        mime_type: &str,
+        filename: &str,
+    ) -> Result<EncryptedMediaUpload, EncryptedMediaError> {
+        self.encrypt_for_upload_with_options(
+            data,
+            mime_type,
+            filename,
+            &MediaProcessingOptions::default(),
+        )
+    }
+
+    /// Encrypt media for upload with custom options
+    ///
+    /// # Parameters
+    /// - `data`: The raw media file data
+    /// - `mime_type`: MIME type of the media (e.g., "image/jpeg")
+    /// - `filename`: Original filename (required for AAD in encryption)
+    /// - `options`: Custom processing options for metadata handling
+    pub fn encrypt_for_upload_with_options(
+        &self,
+        data: &[u8],
+        mime_type: &str,
+        filename: &str,
+        options: &MediaProcessingOptions,
+    ) -> Result<EncryptedMediaUpload, EncryptedMediaError> {
+        let canonical_mime_type = validate_inputs(data, mime_type, filename, options)?;
+
+        let metadata = extract_and_process_metadata(data, &canonical_mime_type, options)?;
+        let original_hash: [u8; 32] = Sha256::digest(data).into();
+        let encryption_key = derive_encryption_key(
+            self.mdk,
+            &self.group_id,
+            &original_hash,
+            &metadata.mime_type,
+            filename,
+        )?;
+        let nonce = derive_encryption_nonce(
+            self.mdk,
+            &self.group_id,
+            &original_hash,
+            &metadata.mime_type,
+            filename,
+        )?;
+
+        let encrypted_data = encrypt_data_with_aad(
+            data,
+            &encryption_key,
+            &nonce,
+            &original_hash,
+            &metadata.mime_type,
+            filename,
+        )?;
+        let encrypted_hash = Sha256::digest(&encrypted_data).into();
+        let encrypted_size = encrypted_data.len() as u64;
+
+        Ok(EncryptedMediaUpload {
+            encrypted_data,
+            original_hash,
+            encrypted_hash,
+            mime_type: metadata.mime_type,
+            filename: filename.to_string(),
+            original_size: data.len() as u64,
+            encrypted_size,
+            dimensions: metadata.dimensions,
+            blurhash: metadata.blurhash,
+        })
+    }
+
+    /// Decrypt downloaded media
+    ///
+    /// The filename for AAD is taken from the MediaReference, which was parsed from the imeta tag.
+    pub fn decrypt_from_download(
+        &self,
+        encrypted_data: &[u8],
+        reference: &MediaReference,
+    ) -> Result<Vec<u8>, EncryptedMediaError> {
+        let encryption_key = derive_encryption_key(
+            self.mdk,
+            &self.group_id,
+            &reference.original_hash,
+            &reference.mime_type,
+            &reference.filename,
+        )?;
+        let nonce = derive_encryption_nonce(
+            self.mdk,
+            &self.group_id,
+            &reference.original_hash,
+            &reference.mime_type,
+            &reference.filename,
+        )?;
+        let decrypted_data = decrypt_data_with_aad(
+            encrypted_data,
+            &encryption_key,
+            &nonce,
+            &reference.original_hash,
+            &reference.mime_type,
+            &reference.filename,
+        )?;
+
+        let calculated_hash: [u8; 32] = Sha256::digest(&decrypted_data).into();
+        if calculated_hash != reference.original_hash {
+            return Err(EncryptedMediaError::HashVerificationFailed);
+        }
+
+        Ok(decrypted_data)
+    }
+
+    /// Create an imeta tag for encrypted media (after upload)
+    ///
+    /// Creates IMETA tag according to Marmot protocol 04.md specification:
+    /// imeta url \<storage_url\> m \<mime_type\> filename \<original_filename\> [dim \<dimensions\>] [blurhash \<blurhash\>] x \<file_hash_hex\> v \<version\>
+    pub fn create_imeta_tag(&self, upload: &EncryptedMediaUpload, uploaded_url: &str) -> NostrTag {
+        let mut tag_values = vec![
+            format!("url {}", uploaded_url),
+            format!("m {}", upload.mime_type), // MIME type should already be canonical
+            format!("filename {}", upload.filename),
+        ];
+
+        if let Some((width, height)) = upload.dimensions {
+            tag_values.push(format!("dim {}x{}", width, height));
+        }
+
+        if let Some(ref blurhash) = upload.blurhash {
+            tag_values.push(format!("blurhash {}", blurhash));
+        }
+
+        // x field contains SHA256 hash of original file content (hex-encoded)
+        tag_values.push(format!("x {}", hex::encode(upload.original_hash)));
+
+        // v field contains encryption version number (currently "1")
+        tag_values.push("v 1".to_string());
+
+        NostrTag::custom(TagKind::Custom("imeta".into()), tag_values)
+    }
+
+    /// Create a media reference from upload result
+    pub fn create_media_reference(
+        &self,
+        upload: &EncryptedMediaUpload,
+        uploaded_url: String,
+    ) -> MediaReference {
+        MediaReference {
+            url: uploaded_url,
+            original_hash: upload.original_hash,
+            mime_type: upload.mime_type.clone(),
+            filename: upload.filename.clone(),
+            dimensions: upload.dimensions,
+        }
+    }
+
+    /// Parse an IMETA tag to create a MediaReference for decryption
+    ///
+    /// Expected IMETA format: url \<storage_url\> m \<mime_type\> filename \<filename\> x \<file_hash_hex\> v \<version\> [dim \<dimensions\>] [blurhash \<blurhash\>]
+    pub fn parse_imeta_tag(
+        &self,
+        imeta_tag: &NostrTag,
+    ) -> Result<MediaReference, EncryptedMediaError> {
+        // Verify this is an imeta tag
+        if imeta_tag.kind() != TagKind::Custom("imeta".into()) {
+            return Err(EncryptedMediaError::InvalidImetaTag {
+                reason: "Not an imeta tag".to_string(),
+            });
+        }
+
+        let tag_values = imeta_tag.clone().to_vec();
+        if tag_values.len() < 2 {
+            return Err(EncryptedMediaError::InvalidImetaTag {
+                reason: "IMETA tag has insufficient fields".to_string(),
+            });
+        }
+
+        let mut url: Option<String> = None;
+        let mut mime_type: Option<String> = None;
+        let mut filename: Option<String> = None;
+        let mut original_hash: Option<[u8; 32]> = None;
+        let mut dimensions: Option<(u32, u32)> = None;
+        let mut version: Option<String> = None;
+
+        // Parse key-value pairs from IMETA tag
+        // Skip the first element which is "imeta"
+        for item in tag_values.iter().skip(1) {
+            let parts: Vec<&str> = item.splitn(2, ' ').collect();
+            if parts.len() != 2 {
+                continue;
+            }
+
+            match parts[0] {
+                "url" => url = Some(parts[1].to_string()),
+                "m" => {
+                    // Use centralized MIME type canonicalization to handle aliases properly
+                    match validate_mime_type(parts[1]) {
+                        Ok(canonical) => mime_type = Some(canonical),
+                        Err(_) => {
+                            return Err(EncryptedMediaError::InvalidImetaTag {
+                                reason: format!("Invalid MIME type: {}", parts[1]),
+                            });
+                        }
+                    }
+                }
+                "x" => {
+                    // Decode hex-encoded original file hash
+                    match hex::decode(parts[1]) {
+                        Ok(bytes) if bytes.len() == 32 => {
+                            let mut hash = [0u8; 32];
+                            hash.copy_from_slice(&bytes);
+                            original_hash = Some(hash);
+                        }
+                        _ => {
+                            return Err(EncryptedMediaError::InvalidImetaTag {
+                                reason: "Invalid 'x' (file_hash) field".to_string(),
+                            })
+                        }
+                    }
+                }
+                "dim" => {
+                    // Parse dimensions in format "widthxheight"
+                    let dim_parts: Vec<&str> = parts[1].split('x').collect();
+                    if dim_parts.len() == 2 {
+                        if let (Ok(width), Ok(height)) =
+                            (dim_parts[0].parse::<u32>(), dim_parts[1].parse::<u32>())
+                        {
+                            dimensions = Some((width, height));
+                        }
+                    }
+                }
+                "filename" => {
+                    filename = Some(parts[1].to_string());
+                }
+                "v" => version = Some(parts[1].to_string()),
+                "blurhash" => {
+                    // Blurhash is optional and not needed for decryption
+                }
+                _ => {
+                    // Ignore unknown fields for forward compatibility
+                }
+            }
+        }
+
+        // Validate required fields
+        let url = url.ok_or(EncryptedMediaError::InvalidImetaTag {
+            reason: "Missing required 'url' field".to_string(),
+        })?;
+        let mime_type = mime_type.ok_or(EncryptedMediaError::InvalidImetaTag {
+            reason: "Missing required 'm' (mime_type) field".to_string(),
+        })?;
+        let original_hash = original_hash.ok_or(EncryptedMediaError::InvalidImetaTag {
+            reason: "Missing or invalid 'x' (file_hash) field".to_string(),
+        })?;
+        let filename = filename.ok_or(EncryptedMediaError::InvalidImetaTag {
+            reason: "Missing required 'filename' field".to_string(),
+        })?;
+
+        // Validate version (currently only support version 1)
+        if let Some(v) = version {
+            if v != "1" {
+                return Err(EncryptedMediaError::DecryptionFailed {
+                    reason: format!("Unsupported encryption version: {}", v),
+                });
+            }
+        }
+
+        Ok(MediaReference {
+            url,
+            original_hash,
+            mime_type,
+            filename,
+            dimensions,
+        })
+    }
+}
+
+impl<Storage> MDK<Storage>
+where
+    Storage: MdkStorageProvider,
+{
+    /// Create an encrypted media manager for a specific group
+    pub fn media_manager(&self, group_id: GroupId) -> EncryptedMediaManager<'_, Storage> {
+        EncryptedMediaManager::new(self, group_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdk_memory_storage::MdkMemoryStorage;
+
+    fn create_test_mdk() -> MDK<MdkMemoryStorage> {
+        MDK::new(MdkMemoryStorage::default())
+    }
+
+    #[test]
+    fn test_create_imeta_tag() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        let upload = EncryptedMediaUpload {
+            encrypted_data: vec![1, 2, 3, 4],
+            original_hash: [0x42; 32],
+            encrypted_hash: [0x43; 32],
+            mime_type: "image/jpeg".to_string(),
+            filename: "test.jpg".to_string(),
+            original_size: 1000,
+            encrypted_size: 1004,
+            dimensions: Some((1920, 1080)),
+            blurhash: Some("LKO2?U%2Tw=w]~RBVZRi};RPxuwH".to_string()),
+        };
+
+        let tag = manager.create_imeta_tag(&upload, "https://example.com/file.jpg");
+
+        // Verify tag structure
+        assert_eq!(tag.kind(), TagKind::Custom("imeta".into()));
+        let values = tag.to_vec();
+
+        // Check required fields
+        assert!(values
+            .iter()
+            .any(|v| v.starts_with("url https://example.com/file.jpg")));
+        assert!(values.iter().any(|v| v.starts_with("m image/jpeg")));
+        assert!(values.iter().any(|v| v.starts_with("filename test.jpg")));
+        assert!(values.iter().any(|v| v.starts_with("dim 1920x1080")));
+        assert!(values
+            .iter()
+            .any(|v| v.starts_with("blurhash LKO2?U%2Tw=w]~RBVZRi};RPxuwH")));
+        assert!(values
+            .iter()
+            .any(|v| v.starts_with(&format!("x {}", hex::encode([0x42; 32])))));
+        assert!(values.iter().any(|v| v.starts_with("v 1")));
+    }
+
+    #[test]
+    fn test_parse_imeta_tag() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Create a valid IMETA tag
+        let tag_values = vec![
+            "url https://example.com/encrypted.jpg".to_string(),
+            "m image/jpeg".to_string(),
+            "filename photo.jpg".to_string(),
+            "dim 1920x1080".to_string(),
+            "blurhash LKO2?U%2Tw=w]~RBVZRi};RPxuwH".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+            "v 1".to_string(),
+        ];
+
+        let imeta_tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+
+        let result = manager.parse_imeta_tag(&imeta_tag);
+        assert!(result.is_ok());
+
+        let media_ref = result.unwrap();
+        assert_eq!(media_ref.url, "https://example.com/encrypted.jpg");
+        assert_eq!(media_ref.mime_type, "image/jpeg");
+        assert_eq!(media_ref.original_hash, [0x42; 32]);
+        assert_eq!(media_ref.filename, "photo.jpg");
+        assert_eq!(media_ref.dimensions, Some((1920, 1080)));
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_invalid() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Test with wrong tag kind
+        let wrong_tag = NostrTag::custom(TagKind::Custom("wrong".into()), vec!["test".to_string()]);
+        let result = manager.parse_imeta_tag(&wrong_tag);
+        assert!(result.is_err());
+
+        // Test with missing required fields
+        let incomplete_tag = NostrTag::custom(
+            TagKind::Custom("imeta".into()),
+            vec![
+                "url https://example.com/test.jpg".to_string(),
+                // Missing mime type and hash
+            ],
+        );
+        let result = manager.parse_imeta_tag(&incomplete_tag);
+        assert!(result.is_err());
+
+        // Test with invalid hash
+        let invalid_hash_tag = NostrTag::custom(
+            TagKind::Custom("imeta".into()),
+            vec![
+                "url https://example.com/test.jpg".to_string(),
+                "m image/jpeg".to_string(),
+                "filename test.jpg".to_string(),
+                "x invalidhash".to_string(),
+            ],
+        );
+        let result = manager.parse_imeta_tag(&invalid_hash_tag);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_media_reference() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        let upload = EncryptedMediaUpload {
+            encrypted_data: vec![1, 2, 3, 4],
+            original_hash: [0x42; 32],
+            encrypted_hash: [0x43; 32],
+            mime_type: "image/png".to_string(),
+            filename: "test.png".to_string(),
+            original_size: 2000,
+            encrypted_size: 2004,
+            dimensions: Some((800, 600)),
+            blurhash: None,
+        };
+
+        let media_ref = manager
+            .create_media_reference(&upload, "https://cdn.example.com/image.png".to_string());
+
+        assert_eq!(media_ref.url, "https://cdn.example.com/image.png");
+        assert_eq!(media_ref.original_hash, [0x42; 32]);
+        assert_eq!(media_ref.mime_type, "image/png");
+        assert_eq!(media_ref.filename, "test.png");
+        assert_eq!(media_ref.dimensions, Some((800, 600)));
+    }
+
+    #[test]
+    fn test_encrypt_for_upload_with_mime_type_aliases() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Test data (not real audio, but that's fine for this test)
+        let test_data = vec![0u8; 1000];
+        let options = MediaProcessingOptions::default();
+
+        // Test with MIME type alias - should canonicalize to proper form
+        let result = manager.encrypt_for_upload_with_options(
+            &test_data,
+            "audio/mp3", // This is an alias for audio/mpeg
+            "song.mp3",
+            &options,
+        );
+
+        // This will fail because we don't have a real MLS group, but we can check
+        // that the validation passes and the error is about the missing group
+        assert!(result.is_err());
+        if let Err(EncryptedMediaError::GroupNotFound) = result {
+            // This is expected - the MIME type validation passed, but we don't have a real group
+        } else {
+            panic!("Expected GroupNotFound error, got: {:?}", result);
+        }
+
+        // Test with another alias
+        let result = manager.encrypt_for_upload_with_options(
+            &test_data,
+            "audio/x-wav", // This is an alias for audio/wav
+            "sound.wav",
+            &options,
+        );
+
+        // Should also fail with GroupNotFound (not a MIME type error)
+        assert!(result.is_err());
+        if let Err(EncryptedMediaError::GroupNotFound) = result {
+            // This is expected - the MIME type validation passed
+        } else {
+            panic!("Expected GroupNotFound error, got: {:?}", result);
+        }
+
+        // Test with unsupported MIME type - should fail with UnsupportedMimeType
+        let result = manager.encrypt_for_upload_with_options(
+            &test_data,
+            "application/pdf", // Unsupported
+            "document.pdf",
+            &options,
+        );
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::UnsupportedMimeType { .. })
+        ));
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_missing_fields() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Test missing URL
+        let tag_values = vec![
+            "m image/jpeg".to_string(),
+            "filename photo.jpg".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidImetaTag { .. })
+        ));
+
+        // Test missing MIME type
+        let tag_values = vec![
+            "url https://example.com/test.jpg".to_string(),
+            "filename photo.jpg".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidImetaTag { .. })
+        ));
+
+        // Test missing filename
+        let tag_values = vec![
+            "url https://example.com/test.jpg".to_string(),
+            "m image/jpeg".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidImetaTag { .. })
+        ));
+
+        // Test missing hash
+        let tag_values = vec![
+            "url https://example.com/test.jpg".to_string(),
+            "m image/jpeg".to_string(),
+            "filename photo.jpg".to_string(),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidImetaTag { .. })
+        ));
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_version_validation() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Test unsupported version
+        let tag_values = vec![
+            "url https://example.com/test.jpg".to_string(),
+            "m image/jpeg".to_string(),
+            "filename photo.jpg".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+            "v 2".to_string(), // Unsupported version
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::DecryptionFailed { .. })
+        ));
+
+        // Test supported version
+        let tag_values = vec![
+            "url https://example.com/test.jpg".to_string(),
+            "m image/jpeg".to_string(),
+            "filename photo.jpg".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+            "v 1".to_string(),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_optional_fields() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Test with minimal required fields only
+        let tag_values = vec![
+            "url https://example.com/test.jpg".to_string(),
+            "m image/jpeg".to_string(),
+            "filename photo.jpg".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(result.is_ok());
+
+        let media_ref = result.unwrap();
+        assert_eq!(media_ref.dimensions, None); // Optional field should be None
+
+        // Test with dimensions
+        let tag_values = vec![
+            "url https://example.com/test.jpg".to_string(),
+            "m image/jpeg".to_string(),
+            "filename photo.jpg".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+            "dim 1920x1080".to_string(),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(result.is_ok());
+
+        let media_ref = result.unwrap();
+        assert_eq!(media_ref.dimensions, Some((1920, 1080)));
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_mime_type_canonicalization() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Test with mixed-case MIME type
+        let tag_values = vec![
+            "url https://example.com/test.jpg".to_string(),
+            "m IMAGE/JPEG".to_string(), // Mixed case
+            "filename photo.jpg".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(result.is_ok());
+
+        let media_ref = result.unwrap();
+        assert_eq!(media_ref.mime_type, "image/jpeg"); // Should be lowercase
+
+        // Test with whitespace around MIME type
+        let tag_values = vec![
+            "url https://example.com/test.png".to_string(),
+            "m  Image/PNG  ".to_string(), // Whitespace and mixed case
+            "filename photo.png".to_string(),
+            format!("x {}", hex::encode([0x43; 32])),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+        assert!(result.is_ok());
+
+        let media_ref = result.unwrap();
+        assert_eq!(media_ref.mime_type, "image/png"); // Should be trimmed and lowercase
+
+        // Test with various supported MIME types and case combinations
+        let test_cases = vec![
+            ("video/MP4", "video/mp4"),
+            ("Audio/MPEG", "audio/mpeg"),
+            ("IMAGE/webp", "image/webp"),
+            ("AUDIO/wav", "audio/wav"),
+        ];
+
+        for (input_mime, expected_mime) in test_cases {
+            let tag_values = vec![
+                "url https://example.com/test.file".to_string(),
+                format!("m {}", input_mime),
+                "filename test.file".to_string(),
+                format!("x {}", hex::encode([0x44; 32])),
+            ];
+            let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+            let result = manager.parse_imeta_tag(&tag);
+            assert!(result.is_ok(), "Failed to parse MIME type: {}", input_mime);
+
+            let media_ref = result.unwrap();
+            assert_eq!(
+                media_ref.mime_type, expected_mime,
+                "MIME type canonicalization failed for input: {}",
+                input_mime
+            );
+        }
+    }
+
+    #[test]
+    fn test_imeta_roundtrip_with_mixed_case_mime() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Simulate an IMETA tag created by a producer that uses mixed-case MIME type
+        let tag_values = vec![
+            "url https://example.com/encrypted.jpg".to_string(),
+            "m IMAGE/JPEG".to_string(), // Mixed case from producer
+            "filename photo.jpg".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+            "v 1".to_string(),
+        ];
+        let imeta_tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+
+        // Parse the IMETA tag (this should canonicalize the MIME type)
+        let result = manager.parse_imeta_tag(&imeta_tag);
+        assert!(result.is_ok());
+
+        let media_ref = result.unwrap();
+
+        // Verify the MIME type was canonicalized to lowercase
+        assert_eq!(media_ref.mime_type, "image/jpeg");
+        assert_eq!(media_ref.url, "https://example.com/encrypted.jpg");
+        assert_eq!(media_ref.filename, "photo.jpg");
+        assert_eq!(media_ref.original_hash, [0x42; 32]);
+
+        // The canonicalized MIME type should now work correctly for key derivation
+        // and decryption operations (even though we can't test the full flow without
+        // a real MLS group, we can verify the MediaReference structure is correct)
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_with_aliases() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Test parsing IMETA tag with MIME type alias
+        let tag_values = vec![
+            "url https://example.com/test.mp3".to_string(),
+            "m audio/mp3".to_string(), // This is an alias for audio/mpeg
+            "filename song.mp3".to_string(),
+            format!("x {}", hex::encode([0x44; 32])),
+            "v 1".to_string(),
+        ];
+        let imeta_tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+
+        let result = manager.parse_imeta_tag(&imeta_tag);
+        assert!(result.is_ok());
+
+        let media_ref = result.unwrap();
+        // Should be canonicalized to the proper MIME type
+        assert_eq!(media_ref.mime_type, "audio/mpeg");
+        assert_eq!(media_ref.url, "https://example.com/test.mp3");
+        assert_eq!(media_ref.filename, "song.mp3");
+        assert_eq!(media_ref.original_hash, [0x44; 32]);
+
+        // Test with another alias
+        let tag_values = vec![
+            "url https://example.com/test.wav".to_string(),
+            "m audio/x-wav".to_string(), // This is an alias for audio/wav
+            "filename sound.wav".to_string(),
+            format!("x {}", hex::encode([0x45; 32])),
+        ];
+        let imeta_tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+
+        let result = manager.parse_imeta_tag(&imeta_tag);
+        assert!(result.is_ok());
+
+        let media_ref = result.unwrap();
+        // Should be canonicalized to the proper MIME type
+        assert_eq!(media_ref.mime_type, "audio/wav");
+        assert_eq!(media_ref.url, "https://example.com/test.wav");
+        assert_eq!(media_ref.filename, "sound.wav");
+        assert_eq!(media_ref.original_hash, [0x45; 32]);
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_with_invalid_mime_type() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        // Test parsing IMETA tag with unsupported MIME type
+        let tag_values = vec![
+            "url https://example.com/test.pdf".to_string(),
+            "m application/pdf".to_string(), // Unsupported MIME type
+            "filename document.pdf".to_string(),
+            format!("x {}", hex::encode([0x46; 32])),
+        ];
+        let imeta_tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+
+        let result = manager.parse_imeta_tag(&imeta_tag);
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidImetaTag { .. })
+        ));
+
+        // Test parsing IMETA tag with invalid MIME type format
+        let tag_values = vec![
+            "url https://example.com/test.file".to_string(),
+            "m invalid".to_string(), // Invalid format
+            "filename test.file".to_string(),
+            format!("x {}", hex::encode([0x47; 32])),
+        ];
+        let imeta_tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+
+        let result = manager.parse_imeta_tag(&imeta_tag);
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidImetaTag { .. })
+        ));
+    }
+}

--- a/crates/mdk-core/src/encrypted_media/manager.rs
+++ b/crates/mdk-core/src/encrypted_media/manager.rs
@@ -14,7 +14,7 @@ use crate::encrypted_media::metadata::extract_and_process_metadata;
 use crate::encrypted_media::types::{
     EncryptedMediaError, EncryptedMediaUpload, MediaProcessingOptions, MediaReference,
 };
-use crate::encrypted_media::validation::{validate_inputs, validate_mime_type};
+use crate::encrypted_media::validation::{validate_inputs, validate_mime_type, validate_filename};
 use crate::{GroupId, MDK};
 use mdk_storage_traits::MdkStorageProvider;
 
@@ -271,7 +271,14 @@ where
                     }
                 }
                 "filename" => {
-                    filename = Some(parts[1].to_string());
+                    match validate_filename(parts[1]) {
+                        Ok(_) => filename = Some(parts[1].to_string()),
+                        Err(_) => {
+                            return Err(EncryptedMediaError::InvalidImetaTag {
+                                reason: format!("Invalid filename: {}", parts[1]),
+                            });
+                        }
+                    }
                 }
                 "v" => version = Some(parts[1].to_string()),
                 "blurhash" => {

--- a/crates/mdk-core/src/encrypted_media/manager.rs
+++ b/crates/mdk-core/src/encrypted_media/manager.rs
@@ -14,7 +14,7 @@ use crate::encrypted_media::metadata::extract_and_process_metadata;
 use crate::encrypted_media::types::{
     EncryptedMediaError, EncryptedMediaUpload, MediaProcessingOptions, MediaReference,
 };
-use crate::encrypted_media::validation::{validate_inputs, validate_mime_type, validate_filename};
+use crate::encrypted_media::validation::{validate_filename, validate_inputs, validate_mime_type};
 use crate::{GroupId, MDK};
 use mdk_storage_traits::MdkStorageProvider;
 
@@ -270,16 +270,14 @@ where
                         }
                     }
                 }
-                "filename" => {
-                    match validate_filename(parts[1]) {
-                        Ok(_) => filename = Some(parts[1].to_string()),
-                        Err(_) => {
-                            return Err(EncryptedMediaError::InvalidImetaTag {
-                                reason: format!("Invalid filename: {}", parts[1]),
-                            });
-                        }
+                "filename" => match validate_filename(parts[1]) {
+                    Ok(_) => filename = Some(parts[1].to_string()),
+                    Err(_) => {
+                        return Err(EncryptedMediaError::InvalidImetaTag {
+                            reason: format!("Invalid filename: {}", parts[1]),
+                        });
                     }
-                }
+                },
                 "v" => version = Some(parts[1].to_string()),
                 "blurhash" => {
                     // Blurhash is optional and not needed for decryption

--- a/crates/mdk-core/src/encrypted_media/manager.rs
+++ b/crates/mdk-core/src/encrypted_media/manager.rs
@@ -174,8 +174,8 @@ where
         // x field contains SHA256 hash of original file content (hex-encoded)
         tag_values.push(format!("x {}", hex::encode(upload.original_hash)));
 
-        // v field contains encryption version number (currently "1")
-        tag_values.push("v 1".to_string());
+        // v field contains encryption version number (currently "mip04-v1")
+        tag_values.push("v mip04-v1".to_string());
 
         NostrTag::custom(TagKind::Custom("imeta".into()), tag_values)
     }
@@ -302,11 +302,11 @@ where
             reason: "Missing required 'filename' field".to_string(),
         })?;
 
-        // Validate version (currently only support version 1)
+        // Validate version (currently only support mip04-v1)
         if let Some(v) = version {
-            if v != "1" {
+            if v != "mip04-v1" {
                 return Err(EncryptedMediaError::DecryptionFailed {
-                    reason: format!("Unsupported encryption version: {}", v),
+                    reason: format!("Unsupported MIP-04 encryption version: {}", v),
                 });
             }
         }
@@ -377,7 +377,7 @@ mod tests {
         assert!(values
             .iter()
             .any(|v| v.starts_with(&format!("x {}", hex::encode([0x42; 32])))));
-        assert!(values.iter().any(|v| v.starts_with("v 1")));
+        assert!(values.iter().any(|v| v.starts_with("v mip04-v1")));
     }
 
     #[test]
@@ -394,7 +394,7 @@ mod tests {
             "dim 1920x1080".to_string(),
             "blurhash LKO2?U%2Tw=w]~RBVZRi};RPxuwH".to_string(),
             format!("x {}", hex::encode([0x42; 32])),
-            "v 1".to_string(),
+            "v mip04-v1".to_string(),
         ];
 
         let imeta_tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
@@ -603,7 +603,7 @@ mod tests {
             "m image/jpeg".to_string(),
             "filename photo.jpg".to_string(),
             format!("x {}", hex::encode([0x42; 32])),
-            "v 2".to_string(), // Unsupported version
+            "v mip04-v2".to_string(), // Unsupported version
         ];
         let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
         let result = manager.parse_imeta_tag(&tag);
@@ -618,7 +618,7 @@ mod tests {
             "m image/jpeg".to_string(),
             "filename photo.jpg".to_string(),
             format!("x {}", hex::encode([0x42; 32])),
-            "v 1".to_string(),
+            "v mip04-v1".to_string(),
         ];
         let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
         let result = manager.parse_imeta_tag(&tag);
@@ -735,7 +735,7 @@ mod tests {
             "m IMAGE/JPEG".to_string(), // Mixed case from producer
             "filename photo.jpg".to_string(),
             format!("x {}", hex::encode([0x42; 32])),
-            "v 1".to_string(),
+            "v mip04-v1".to_string(),
         ];
         let imeta_tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
 
@@ -768,7 +768,7 @@ mod tests {
             "m audio/mp3".to_string(), // This is an alias for audio/mpeg
             "filename song.mp3".to_string(),
             format!("x {}", hex::encode([0x44; 32])),
-            "v 1".to_string(),
+            "v mip04-v1".to_string(),
         ];
         let imeta_tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
 

--- a/crates/mdk-core/src/encrypted_media/metadata.rs
+++ b/crates/mdk-core/src/encrypted_media/metadata.rs
@@ -85,7 +85,7 @@ pub fn process_image_metadata(
     }
 
     // Process EXIF data (doesn't require image decode)
-    if !options.strip_exif {
+    if !options.sanitize_exif {
         metadata.cleaned_exif = extract_safe_exif(data);
     }
 
@@ -599,7 +599,7 @@ mod tests {
         let options = MediaProcessingOptions {
             preserve_dimensions: true,
             generate_blurhash: false,
-            strip_exif: true,
+            sanitize_exif: true,
             max_dimension: Some(100),
             max_file_size: None,
         };
@@ -614,7 +614,7 @@ mod tests {
         let strict_options = MediaProcessingOptions {
             preserve_dimensions: true,
             generate_blurhash: false,
-            strip_exif: true,
+            sanitize_exif: true,
             max_dimension: Some(0), // This should cause validation to fail
             max_file_size: None,
         };

--- a/crates/mdk-core/src/encrypted_media/metadata.rs
+++ b/crates/mdk-core/src/encrypted_media/metadata.rs
@@ -1,0 +1,637 @@
+//! Metadata extraction and processing for encrypted media
+//!
+//! This module handles extraction and processing of metadata from media files,
+//! with a focus on privacy and security. It includes EXIF processing, image
+//! metadata extraction, and blurhash generation.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+
+use exif::{Reader as ExifReader, Tag as ExifTag, Value as ExifValue};
+
+use crate::encrypted_media::types::{EncryptedMediaError, MediaMetadata, MediaProcessingOptions};
+use crate::encrypted_media::validation::validate_image_dimensions;
+
+/// Extract and process metadata from media file
+///
+/// The mime_type parameter should be the canonical (normalized) MIME type
+/// to ensure consistency in cryptographic operations.
+pub fn extract_and_process_metadata(
+    data: &[u8],
+    mime_type: &str,
+    options: &MediaProcessingOptions,
+) -> Result<MediaMetadata, EncryptedMediaError> {
+    let mut metadata = MediaMetadata {
+        mime_type: mime_type.to_string(),
+        dimensions: None,
+        blurhash: None,
+        original_size: data.len() as u64,
+        cleaned_exif: HashMap::new(),
+    };
+
+    // Process image metadata if it's an image
+    if mime_type.starts_with("image/") {
+        metadata = process_image_metadata(data, metadata, options)?;
+    }
+
+    Ok(metadata)
+}
+
+/// Process image-specific metadata
+pub fn process_image_metadata(
+    data: &[u8],
+    mut metadata: MediaMetadata,
+    options: &MediaProcessingOptions,
+) -> Result<MediaMetadata, EncryptedMediaError> {
+    use image::ImageReader;
+
+    // First, get dimensions without full decode for performance
+    let img_reader = ImageReader::new(Cursor::new(data))
+        .with_guessed_format()
+        .map_err(|e| EncryptedMediaError::MetadataExtractionFailed {
+            reason: format!("Failed to read image: {}", e),
+        })?;
+
+    let (width, height) = img_reader.into_dimensions().map_err(|e| {
+        EncryptedMediaError::MetadataExtractionFailed {
+            reason: format!("Failed to get image dimensions: {}", e),
+        }
+    })?;
+
+    // Validate dimensions early - fail fast if image is too large
+    validate_image_dimensions(width, height, options)?;
+
+    // Store dimensions if requested
+    if options.preserve_dimensions {
+        metadata.dimensions = Some((width, height));
+    }
+
+    // Only decode the full image if we need to generate blurhash
+    if options.generate_blurhash {
+        let img_reader = ImageReader::new(Cursor::new(data))
+            .with_guessed_format()
+            .map_err(|e| EncryptedMediaError::MetadataExtractionFailed {
+                reason: format!("Failed to read image for blurhash: {}", e),
+            })?;
+
+        let img =
+            img_reader
+                .decode()
+                .map_err(|e| EncryptedMediaError::MetadataExtractionFailed {
+                    reason: format!("Failed to decode image for blurhash: {}", e),
+                })?;
+
+        metadata.blurhash = generate_blurhash(&img);
+    }
+
+    // Process EXIF data (doesn't require image decode)
+    if !options.strip_exif {
+        metadata.cleaned_exif = extract_safe_exif(data);
+    }
+
+    Ok(metadata)
+}
+
+/// Generate blurhash for an image
+pub fn generate_blurhash(img: &image::DynamicImage) -> Option<String> {
+    use blurhash::encode;
+
+    // Resize image for blurhash (max 32x32 for performance)
+    let small_img = img.resize(32, 32, image::imageops::FilterType::Lanczos3);
+    let rgb_img = small_img.to_rgb8();
+
+    encode(4, 3, rgb_img.width(), rgb_img.height(), rgb_img.as_raw()).ok()
+}
+
+/// Extract safe EXIF data (removing sensitive information)
+///
+/// This method implements a privacy-first approach to EXIF data handling:
+/// 1. Strips all potentially sensitive metadata (GPS, device info, timestamps, etc.)
+/// 2. Only preserves technical metadata that's safe for sharing
+/// 3. Validates data integrity to detect potential exploits
+pub fn extract_safe_exif(data: &[u8]) -> HashMap<String, String> {
+    let mut safe_exif = HashMap::new();
+
+    // Try to parse EXIF data
+    let exif_reader = match ExifReader::new().read_from_container(&mut Cursor::new(data)) {
+        Ok(exif) => exif,
+        Err(_) => {
+            // No EXIF data or parsing failed - return empty map (safest approach)
+            return safe_exif;
+        }
+    };
+
+    // Define safe EXIF fields that don't compromise privacy
+    let safe_fields = get_safe_exif_fields();
+
+    // Extract only safe fields
+    for field in exif_reader.fields() {
+        // Check if this field is in our safe list
+        if let Some(safe_name) = safe_fields.get(&field.tag) {
+            // Additional validation for specific fields
+            if is_exif_value_safe(field.tag, &field.value) {
+                let value_str = format_exif_value(&field.value);
+                if !value_str.is_empty() && value_str.len() <= 100 {
+                    safe_exif.insert(safe_name.clone(), value_str);
+                }
+            }
+        }
+    }
+
+    // Perform basic security validation
+    if let Err(e) = validate_exif_security(&exif_reader) {
+        tracing::warn!("EXIF security validation failed: {}", e);
+        // Return empty map for security - don't process potentially malicious EXIF
+        return HashMap::new();
+    }
+
+    safe_exif
+}
+
+/// Get whitelist of safe EXIF fields that don't compromise privacy
+pub fn get_safe_exif_fields() -> HashMap<ExifTag, String> {
+    let mut safe_fields = HashMap::new();
+
+    // Technical camera settings (safe to preserve)
+    safe_fields.insert(ExifTag::FNumber, "f_number".to_string());
+    safe_fields.insert(ExifTag::ExposureTime, "exposure_time".to_string());
+    safe_fields.insert(ExifTag::ISOSpeed, "iso".to_string());
+    safe_fields.insert(ExifTag::FocalLength, "focal_length".to_string());
+    safe_fields.insert(ExifTag::Flash, "flash".to_string());
+    safe_fields.insert(ExifTag::WhiteBalance, "white_balance".to_string());
+    safe_fields.insert(ExifTag::ExposureMode, "exposure_mode".to_string());
+    safe_fields.insert(ExifTag::SceneCaptureType, "scene_type".to_string());
+
+    // Image technical properties (safe)
+    safe_fields.insert(ExifTag::ColorSpace, "color_space".to_string());
+    safe_fields.insert(ExifTag::Orientation, "orientation".to_string());
+    safe_fields.insert(ExifTag::ResolutionUnit, "resolution_unit".to_string());
+    safe_fields.insert(ExifTag::XResolution, "x_resolution".to_string());
+    safe_fields.insert(ExifTag::YResolution, "y_resolution".to_string());
+
+    // Note: We explicitly exclude:
+    // - GPS data (Tag::GPSLatitude, Tag::GPSLongitude, etc.)
+    // - Device identifiers (Tag::Make, Tag::Model, Tag::Software, Tag::SerialNumber)
+    // - Timestamps (Tag::DateTime, Tag::DateTimeOriginal, Tag::DateTimeDigitized)
+    // - User comments (Tag::UserComment, Tag::ImageDescription)
+    // - Thumbnail data
+    // - Maker notes (proprietary data that could contain anything)
+
+    safe_fields
+}
+
+/// Validate that an EXIF value is safe to preserve
+pub fn is_exif_value_safe(_tag: ExifTag, value: &ExifValue) -> bool {
+    match value {
+        // Reject any values that could contain embedded data or exploits
+        ExifValue::Undefined(data, _) => {
+            // Undefined data could contain anything - be very conservative
+            data.len() <= 32 && is_data_safe(data)
+        }
+        ExifValue::Ascii(strings) => {
+            // ASCII strings should be reasonable length and not contain suspicious patterns
+            strings.iter().all(|s| {
+                s.len() <= 50
+                    && s.iter()
+                        .all(|&b| b.is_ascii() && !char::from(b).is_control())
+                    && !contains_suspicious_patterns(&String::from_utf8_lossy(s))
+            })
+        }
+        // Numeric values are generally safe
+        ExifValue::Byte(_)
+        | ExifValue::Short(_)
+        | ExifValue::Long(_)
+        | ExifValue::SByte(_)
+        | ExifValue::SShort(_)
+        | ExifValue::SLong(_)
+        | ExifValue::Float(_)
+        | ExifValue::Double(_) => true,
+
+        // Rational values are safe
+        ExifValue::Rational(_) | ExifValue::SRational(_) => true,
+
+        // Be conservative with unknown types
+        _ => false,
+    }
+}
+
+/// Check if binary data appears safe (no suspicious patterns)
+pub fn is_data_safe(data: &[u8]) -> bool {
+    // Check for suspicious patterns that might indicate embedded exploits
+
+    // Reject data with too many null bytes (could be padding for exploits)
+    let null_count = data.iter().filter(|&&b| b == 0).count();
+    if null_count > data.len() / 2 {
+        return false;
+    }
+
+    // Reject data with executable signatures
+    if data.len() >= 2 {
+        match &data[0..2] {
+            [0x4D, 0x5A] => return false, // PE executable
+            [0x7F, 0x45] => return false, // ELF executable
+            [0xCA, 0xFE] => return false, // Mach-O executable
+            [0xFE, 0xED] => return false, // Mach-O executable
+            _ => {}
+        }
+    }
+
+    // Check for script-like patterns
+    if data.len() >= 4
+        && (data.starts_with(b"<scr")
+            || data.starts_with(b"java")
+            || data.starts_with(b"#!/")
+            || data.starts_with(b"<?ph"))
+    {
+        return false;
+    }
+
+    true
+}
+
+/// Check for suspicious patterns in ASCII strings
+pub fn contains_suspicious_patterns(s: &str) -> bool {
+    let suspicious_patterns = [
+        "javascript:",
+        "data:",
+        "vbscript:",
+        "file://",
+        "ftp://",
+        "<script",
+        "</script",
+        "<?php",
+        "#!/",
+        "cmd.exe",
+        "powershell",
+        "eval(",
+        "exec(",
+        "system(",
+        "shell_exec",
+        "passthru",
+    ];
+
+    let lower_s = s.to_lowercase();
+    suspicious_patterns
+        .iter()
+        .any(|pattern| lower_s.contains(pattern))
+}
+
+/// Format EXIF value as string for storage
+pub fn format_exif_value(value: &ExifValue) -> String {
+    match value {
+        ExifValue::Ascii(strings) => strings
+            .iter()
+            .map(|s| String::from_utf8_lossy(s).to_string())
+            .collect::<Vec<_>>()
+            .join("; "),
+        ExifValue::Byte(values) => values
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::Short(values) => values
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::Long(values) => values
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::Rational(values) => values
+            .iter()
+            .map(|r| {
+                if r.denom == 0 {
+                    "undefined".to_string()
+                } else {
+                    format!("{}/{}", r.num, r.denom)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::SByte(values) => values
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::SShort(values) => values
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::SLong(values) => values
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::SRational(values) => values
+            .iter()
+            .map(|r| {
+                if r.denom == 0 {
+                    "undefined".to_string()
+                } else {
+                    format!("{}/{}", r.num, r.denom)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::Float(values) => values
+            .iter()
+            .map(|v| format!("{:.3}", v))
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::Double(values) => values
+            .iter()
+            .map(|v| format!("{:.3}", v))
+            .collect::<Vec<_>>()
+            .join(", "),
+        ExifValue::Undefined(data, _) => {
+            // For undefined data, only show length to avoid exposing content
+            format!("binary({} bytes)", data.len())
+        }
+        _ => "unknown".to_string(),
+    }
+}
+
+/// Perform basic security validation on EXIF data
+///
+/// Returns an error if potentially malicious patterns are detected
+pub fn validate_exif_security(exif: &exif::Exif) -> Result<(), EncryptedMediaError> {
+    // Check for suspicious field counts (potential DoS via memory exhaustion)
+    if exif.fields().len() > 1000 {
+        return Err(EncryptedMediaError::MetadataExtractionFailed {
+            reason: format!(
+                "EXIF data contains suspiciously high number of fields: {} (max: 1000)",
+                exif.fields().len()
+            ),
+        });
+    }
+
+    // Check for fields with suspicious data sizes
+    for field in exif.fields() {
+        let value_size = match &field.value {
+            ExifValue::Undefined(data, _) => data.len(),
+            ExifValue::Ascii(strings) => strings.iter().map(|s| s.len()).sum(),
+            _ => 0,
+        };
+
+        if value_size > 10000 {
+            return Err(EncryptedMediaError::MetadataExtractionFailed {
+                reason: format!(
+                    "EXIF field {} contains suspiciously large data: {} bytes (max: 10000)",
+                    field.tag, value_size
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exif::Rational;
+
+    #[test]
+    fn test_safe_exif_fields() {
+        let safe_fields = get_safe_exif_fields();
+
+        // Should include technical camera settings
+        assert!(safe_fields.contains_key(&ExifTag::FNumber));
+        assert!(safe_fields.contains_key(&ExifTag::ExposureTime));
+        assert!(safe_fields.contains_key(&ExifTag::ISOSpeed));
+
+        // Should include safe image properties
+        assert!(safe_fields.contains_key(&ExifTag::Orientation));
+        assert!(safe_fields.contains_key(&ExifTag::ColorSpace));
+
+        // Should NOT include sensitive fields (we can't test for their absence directly
+        // since they're not in our safe list, but we can verify our list is reasonably sized)
+        assert!(safe_fields.len() < 20); // Should be a curated, small list
+    }
+
+    #[test]
+    fn test_is_data_safe() {
+        // Safe data
+        assert!(is_data_safe(&[1, 2, 3, 4, 5]));
+        assert!(is_data_safe(&[]));
+
+        // Unsafe data - too many nulls
+        assert!(!is_data_safe(&[0, 0, 0, 0, 0, 1]));
+
+        // Unsafe data - executable signatures
+        assert!(!is_data_safe(&[0x4D, 0x5A, 0x90, 0x00])); // PE
+        assert!(!is_data_safe(&[0x7F, 0x45, 0x4C, 0x46])); // ELF
+        assert!(!is_data_safe(&[0xCA, 0xFE, 0xBA, 0xBE])); // Mach-O
+
+        // Unsafe data - script patterns
+        assert!(!is_data_safe(b"<script>alert(1)</script>"));
+        assert!(!is_data_safe(b"#!/bin/bash"));
+        assert!(!is_data_safe(b"<?php echo 'hi'; ?>"));
+    }
+
+    #[test]
+    fn test_contains_suspicious_patterns() {
+        // Safe strings
+        assert!(!contains_suspicious_patterns("Canon EOS R5"));
+        assert!(!contains_suspicious_patterns("f/2.8"));
+        assert!(!contains_suspicious_patterns("1/125"));
+
+        // Suspicious strings
+        assert!(contains_suspicious_patterns("javascript:alert(1)"));
+        assert!(contains_suspicious_patterns("data:text/html,<script>"));
+        assert!(contains_suspicious_patterns("file:///etc/passwd"));
+        assert!(contains_suspicious_patterns("eval(document.cookie)"));
+        assert!(contains_suspicious_patterns("cmd.exe /c dir"));
+        assert!(contains_suspicious_patterns(
+            "<?php system($_GET['cmd']); ?>"
+        ));
+    }
+
+    #[test]
+    fn test_is_exif_value_safe() {
+        // Safe values
+        assert!(is_exif_value_safe(
+            ExifTag::FNumber,
+            &ExifValue::Rational(vec![Rational { num: 28, denom: 10 }])
+        ));
+        assert!(is_exif_value_safe(
+            ExifTag::ISOSpeed,
+            &ExifValue::Short(vec![800])
+        ));
+        assert!(is_exif_value_safe(
+            ExifTag::Flash,
+            &ExifValue::Short(vec![16])
+        ));
+
+        // Safe ASCII
+        assert!(is_exif_value_safe(
+            ExifTag::ColorSpace,
+            &ExifValue::Ascii(vec![b"sRGB".to_vec()])
+        ));
+
+        // Unsafe ASCII - too long
+        let long_string = "a".repeat(100);
+        assert!(!is_exif_value_safe(
+            ExifTag::ColorSpace,
+            &ExifValue::Ascii(vec![long_string.into_bytes()])
+        ));
+
+        // Unsafe ASCII - suspicious content
+        assert!(!is_exif_value_safe(
+            ExifTag::ColorSpace,
+            &ExifValue::Ascii(vec![b"javascript:alert(1)".to_vec()])
+        ));
+
+        // Unsafe undefined data - too large
+        let large_data = vec![0u8; 100];
+        assert!(!is_exif_value_safe(
+            ExifTag::ColorSpace,
+            &ExifValue::Undefined(large_data, 0)
+        ));
+
+        // Unsafe undefined data - suspicious content
+        assert!(!is_exif_value_safe(
+            ExifTag::ColorSpace,
+            &ExifValue::Undefined(vec![0x4D, 0x5A, 0x90, 0x00], 0)
+        ));
+    }
+
+    #[test]
+    fn test_format_exif_value() {
+        // Test different value types
+        assert_eq!(
+            format_exif_value(&ExifValue::Ascii(vec![b"sRGB".to_vec()])),
+            "sRGB"
+        );
+        assert_eq!(format_exif_value(&ExifValue::Short(vec![800])), "800");
+        assert_eq!(
+            format_exif_value(&ExifValue::Rational(vec![Rational { num: 28, denom: 10 }])),
+            "28/10"
+        );
+        assert_eq!(format_exif_value(&ExifValue::Float(vec![2.8])), "2.800");
+
+        // Test multiple values
+        assert_eq!(
+            format_exif_value(&ExifValue::Short(vec![800, 1600])),
+            "800, 1600"
+        );
+
+        // Test undefined data (should show length only)
+        assert_eq!(
+            format_exif_value(&ExifValue::Undefined(vec![1, 2, 3, 4], 0)),
+            "binary(4 bytes)"
+        );
+
+        // Test division by zero
+        assert_eq!(
+            format_exif_value(&ExifValue::Rational(vec![Rational { num: 1, denom: 0 }])),
+            "undefined"
+        );
+    }
+
+    #[test]
+    fn test_extract_safe_exif_empty_data() {
+        // Test with data that has no EXIF
+        let empty_data = vec![0u8; 100];
+        let result = extract_safe_exif(&empty_data);
+        assert!(result.is_empty());
+
+        // Test with empty data
+        let result = extract_safe_exif(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_exif_security_validation_behavior() {
+        // Test that extract_safe_exif returns empty map when security validation fails
+        // We can't easily create malicious EXIF data in tests, but we can verify the behavior
+        // by testing with empty/invalid data which should be handled safely
+
+        // Test with completely invalid EXIF data
+        let invalid_exif_data = vec![0xFF, 0xE1, 0x00, 0x16]; // Invalid EXIF header
+        let result = extract_safe_exif(&invalid_exif_data);
+        // Should return empty map for invalid data (safe fallback)
+        assert!(result.is_empty());
+
+        // Test with random binary data that might trigger security checks
+        let random_data = vec![0u8; 50000]; // Large random data
+        let result = extract_safe_exif(&random_data);
+        // Should return empty map for unparseable data (safe fallback)
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_process_image_metadata_dimension_validation() {
+        use crate::encrypted_media::types::MediaProcessingOptions;
+
+        // Create a simple 1x1 PNG image for testing
+        let png_data = vec![
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+            0x00, 0x00, 0x00, 0x0D, // IHDR chunk length
+            0x49, 0x48, 0x44, 0x52, // IHDR
+            0x00, 0x00, 0x00, 0x01, // Width: 1
+            0x00, 0x00, 0x00, 0x01, // Height: 1
+            0x08, 0x02, 0x00, 0x00,
+            0x00, // Bit depth, color type, compression, filter, interlace
+            0x90, 0x77, 0x53, 0xDE, // CRC
+            0x00, 0x00, 0x00, 0x0C, // IDAT chunk length
+            0x49, 0x44, 0x41, 0x54, // IDAT
+            0x08, 0x99, 0x01, 0x01, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
+            0x00, // Compressed data
+            0x02, 0x00, 0x01, // CRC
+            0x00, 0x00, 0x00, 0x00, // IEND chunk length
+            0x49, 0x45, 0x4E, 0x44, // IEND
+            0xAE, 0x42, 0x60, 0x82, // CRC
+        ];
+
+        let metadata = MediaMetadata {
+            mime_type: "image/png".to_string(),
+            dimensions: None,
+            blurhash: None,
+            original_size: png_data.len() as u64,
+            cleaned_exif: HashMap::new(),
+        };
+
+        // Test with dimension preservation enabled, blurhash disabled
+        let options = MediaProcessingOptions {
+            preserve_dimensions: true,
+            generate_blurhash: false,
+            strip_exif: true,
+            max_dimension: Some(100),
+            max_file_size: None,
+        };
+
+        let result = process_image_metadata(&png_data, metadata.clone(), &options);
+        assert!(result.is_ok());
+        let processed = result.unwrap();
+        assert_eq!(processed.dimensions, Some((1, 1)));
+        assert!(processed.blurhash.is_none()); // Should be None since generate_blurhash is false
+
+        // Test with dimension validation failure
+        let strict_options = MediaProcessingOptions {
+            preserve_dimensions: true,
+            generate_blurhash: false,
+            strip_exif: true,
+            max_dimension: Some(0), // This should cause validation to fail
+            max_file_size: None,
+        };
+
+        let result = process_image_metadata(&png_data, metadata, &strict_options);
+        assert!(result.is_err());
+        if let Err(EncryptedMediaError::DimensionsTooLarge {
+            width,
+            height,
+            max_dimension,
+        }) = result
+        {
+            assert_eq!(width, 1);
+            assert_eq!(height, 1);
+            assert_eq!(max_dimension, 0);
+        } else {
+            panic!("Expected DimensionsTooLarge error");
+        }
+    }
+}

--- a/crates/mdk-core/src/encrypted_media/mod.rs
+++ b/crates/mdk-core/src/encrypted_media/mod.rs
@@ -22,7 +22,4 @@ pub use types::{
 pub use manager::EncryptedMediaManager;
 
 // Re-export constants that users might need
-pub use types::{
-    MAX_FILENAME_LENGTH, MAX_FILE_SIZE, MAX_IMAGE_DIMENSION, MIME_TYPE_ALIASES,
-    SUPPORTED_MIME_TYPES,
-};
+pub use types::{MAX_FILENAME_LENGTH, MAX_FILE_SIZE, MAX_IMAGE_DIMENSION};

--- a/crates/mdk-core/src/encrypted_media/mod.rs
+++ b/crates/mdk-core/src/encrypted_media/mod.rs
@@ -1,0 +1,28 @@
+//! Encrypted Media support for the Marmot protocol
+//!
+//! This module implements the Encrypted Media specification from the Marmot protocol (04.md),
+//! providing functionality for secure media sharing within MLS groups on Nostr.
+//!
+//! The Encrypted Media feature allows group members to share media files (images, videos, etc.)
+//! in a secure manner, leveraging the MLS group's encryption keys and Nostr's event system.
+
+// Internal modules
+pub mod crypto;
+pub mod manager;
+pub mod metadata;
+pub mod types;
+pub mod validation;
+
+// Re-export public API
+pub use types::{
+    EncryptedMediaError, EncryptedMediaUpload, MediaMetadata, MediaProcessingOptions,
+    MediaReference,
+};
+
+pub use manager::EncryptedMediaManager;
+
+// Re-export constants that users might need
+pub use types::{
+    MAX_FILENAME_LENGTH, MAX_FILE_SIZE, MAX_IMAGE_DIMENSION, MIME_TYPE_ALIASES,
+    SUPPORTED_MIME_TYPES,
+};

--- a/crates/mdk-core/src/encrypted_media/types.rs
+++ b/crates/mdk-core/src/encrypted_media/types.rs
@@ -5,8 +5,8 @@
 
 use std::collections::HashMap;
 
-/// Maximum file size for encrypted media (50MB)
-pub const MAX_FILE_SIZE: usize = 50 * 1024 * 1024;
+/// Maximum file size for encrypted media (100MB)
+pub const MAX_FILE_SIZE: usize = 100 * 1024 * 1024;
 
 /// Maximum filename length
 pub const MAX_FILENAME_LENGTH: usize = 210;

--- a/crates/mdk-core/src/encrypted_media/types.rs
+++ b/crates/mdk-core/src/encrypted_media/types.rs
@@ -1,0 +1,370 @@
+//! Type definitions for encrypted media functionality
+//!
+//! This module contains all the core types, constants, and error definitions
+//! used throughout the encrypted media system.
+
+use std::collections::HashMap;
+
+/// Maximum file size for encrypted media (50MB)
+pub const MAX_FILE_SIZE: usize = 50 * 1024 * 1024;
+
+/// Maximum filename length
+pub const MAX_FILENAME_LENGTH: usize = 210;
+
+/// Maximum image dimension (width or height) - supports flagship phone cameras (200MP)
+pub const MAX_IMAGE_DIMENSION: u32 = 16384;
+
+/// Supported MIME types for encrypted media (canonical forms)
+pub const SUPPORTED_MIME_TYPES: &[&str] = &[
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+    "video/mp4",
+    "video/webm",
+    "audio/mpeg", // Canonical form for MP3
+    "audio/wav",
+    "audio/ogg",
+];
+
+/// MIME type aliases that map to canonical forms
+pub const MIME_TYPE_ALIASES: &[(&str, &str)] = &[
+    ("audio/mp3", "audio/mpeg"),  // Legacy alias for MP3
+    ("audio/x-wav", "audio/wav"), // Alternative WAV format
+    ("audio/wave", "audio/wav"),  // Alternative WAV format
+];
+
+/// Configuration options for media processing
+#[derive(Debug, Clone)]
+pub struct MediaProcessingOptions {
+    /// Strip EXIF and other metadata for privacy (default: true)
+    pub strip_exif: bool,
+    /// Preserve image dimensions in metadata (default: true)
+    pub preserve_dimensions: bool,
+    /// Generate blurhash for images (default: true)
+    pub generate_blurhash: bool,
+    /// Maximum allowed dimension for images (default: uses MAX_IMAGE_DIMENSION)
+    pub max_dimension: Option<u32>,
+    /// Custom size limit (default: uses MAX_FILE_SIZE)
+    pub max_file_size: Option<usize>,
+}
+
+impl Default for MediaProcessingOptions {
+    fn default() -> Self {
+        Self {
+            strip_exif: true,          // Privacy-first default
+            preserve_dimensions: true, // Useful for display
+            generate_blurhash: true,   // Good UX
+            max_dimension: Some(MAX_IMAGE_DIMENSION),
+            max_file_size: None,
+        }
+    }
+}
+
+/// Metadata extracted from media files
+#[derive(Debug, Clone)]
+pub struct MediaMetadata {
+    /// MIME type of the media
+    pub mime_type: String,
+    /// Dimensions for images/videos (width, height)
+    pub dimensions: Option<(u32, u32)>,
+    /// Blurhash for images
+    pub blurhash: Option<String>,
+    /// Original file size in bytes
+    pub original_size: u64,
+    /// Cleaned EXIF data (if any should be preserved)
+    pub cleaned_exif: HashMap<String, String>,
+}
+
+/// Encrypted media ready for upload
+#[derive(Debug, Clone)]
+pub struct EncryptedMediaUpload {
+    /// The encrypted media data
+    pub encrypted_data: Vec<u8>,
+    /// Hash of the original (unencrypted) data
+    pub original_hash: [u8; 32],
+    /// Hash of the encrypted data (for verification)
+    pub encrypted_hash: [u8; 32],
+    /// MIME type of the original media
+    pub mime_type: String,
+    /// Original filename
+    pub filename: String,
+    /// Size of original data before encryption
+    pub original_size: u64,
+    /// Size of encrypted data
+    pub encrypted_size: u64,
+    /// Image/video dimensions if applicable
+    pub dimensions: Option<(u32, u32)>,
+    /// Blurhash for images
+    pub blurhash: Option<String>,
+}
+
+/// Reference to encrypted media
+#[derive(Debug, Clone)]
+pub struct MediaReference {
+    /// URL where the encrypted media is stored
+    pub url: String,
+    /// Hash of original data for verification
+    pub original_hash: [u8; 32],
+    /// MIME type
+    pub mime_type: String,
+    /// Original filename
+    pub filename: String,
+    /// Dimensions if applicable
+    pub dimensions: Option<(u32, u32)>,
+}
+
+/// Errors that can occur during encrypted media operations
+#[derive(Debug, thiserror::Error)]
+pub enum EncryptedMediaError {
+    /// File is too large
+    #[error("File size {size} exceeds maximum allowed size {max_size}")]
+    FileTooLarge {
+        /// The actual file size
+        size: usize,
+        /// The maximum allowed file size
+        max_size: usize,
+    },
+
+    /// Unsupported MIME type
+    #[error("MIME type '{mime_type}' is not supported")]
+    UnsupportedMimeType {
+        /// The unsupported MIME type
+        mime_type: String,
+    },
+
+    /// Invalid MIME type format
+    #[error("Invalid MIME type format: {mime_type}")]
+    InvalidMimeType {
+        /// The invalid MIME type
+        mime_type: String,
+    },
+
+    /// Filename is too long
+    #[error("Filename length {length} exceeds maximum {max_length}")]
+    FilenameTooLong {
+        /// The actual filename length
+        length: usize,
+        /// The maximum allowed filename length
+        max_length: usize,
+    },
+
+    /// Filename is empty or invalid
+    #[error("Filename cannot be empty")]
+    EmptyFilename,
+
+    /// Filename contains invalid characters
+    #[error("Filename contains invalid characters")]
+    InvalidFilename,
+
+    /// Image dimensions are too large
+    #[error("Image dimensions {width}x{height} exceed maximum {max_dimension}")]
+    DimensionsTooLarge {
+        /// The image width in pixels
+        width: u32,
+        /// The image height in pixels
+        height: u32,
+        /// The maximum allowed dimension
+        max_dimension: u32,
+    },
+
+    /// Encryption failed
+    #[error("Encryption failed: {reason}")]
+    EncryptionFailed {
+        /// The reason for encryption failure
+        reason: String,
+    },
+
+    /// Decryption failed
+    #[error("Decryption failed: {reason}")]
+    DecryptionFailed {
+        /// The reason for decryption failure
+        reason: String,
+    },
+
+    /// Metadata extraction failed
+    #[error("Failed to extract metadata: {reason}")]
+    MetadataExtractionFailed {
+        /// The reason for metadata extraction failure
+        reason: String,
+    },
+
+    /// Hash verification failed
+    #[error("Hash verification failed")]
+    HashVerificationFailed,
+
+    /// Group not found
+    #[error("MLS group not found")]
+    GroupNotFound,
+
+    /// Invalid nonce
+    #[error("Invalid encryption nonce")]
+    InvalidNonce,
+
+    /// Invalid IMETA tag format
+    #[error("Invalid IMETA tag format: {reason}")]
+    InvalidImetaTag {
+        /// The reason for the invalid IMETA tag
+        reason: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_media_processing_options_default() {
+        let options = MediaProcessingOptions::default();
+        assert!(options.strip_exif);
+        assert!(options.preserve_dimensions);
+        assert!(options.generate_blurhash);
+        assert_eq!(options.max_dimension, Some(MAX_IMAGE_DIMENSION));
+        assert_eq!(options.max_file_size, None);
+    }
+
+    #[test]
+    fn test_supported_mime_types() {
+        assert!(SUPPORTED_MIME_TYPES.contains(&"image/jpeg"));
+        assert!(SUPPORTED_MIME_TYPES.contains(&"image/png"));
+        assert!(SUPPORTED_MIME_TYPES.contains(&"video/mp4"));
+        assert!(SUPPORTED_MIME_TYPES.contains(&"audio/mpeg")); // Canonical form for MP3
+        assert!(SUPPORTED_MIME_TYPES.contains(&"audio/wav"));
+        assert!(!SUPPORTED_MIME_TYPES.contains(&"audio/mp3")); // This is now an alias, not canonical
+        assert!(!SUPPORTED_MIME_TYPES.contains(&"application/pdf"));
+    }
+
+    #[test]
+    fn test_mime_type_aliases() {
+        // Test that aliases are properly defined
+        assert!(MIME_TYPE_ALIASES.contains(&("audio/mp3", "audio/mpeg")));
+        assert!(MIME_TYPE_ALIASES.contains(&("audio/x-wav", "audio/wav")));
+        assert!(MIME_TYPE_ALIASES.contains(&("audio/wave", "audio/wav")));
+
+        // Verify all alias targets are in supported types
+        for (_, canonical) in MIME_TYPE_ALIASES {
+            assert!(
+                SUPPORTED_MIME_TYPES.contains(canonical),
+                "Alias target '{}' not found in SUPPORTED_MIME_TYPES",
+                canonical
+            );
+        }
+    }
+
+    #[test]
+    fn test_media_processing_options() {
+        let default_options = MediaProcessingOptions::default();
+        assert!(default_options.strip_exif);
+        assert!(default_options.preserve_dimensions);
+        assert!(default_options.generate_blurhash);
+        assert_eq!(default_options.max_dimension, Some(MAX_IMAGE_DIMENSION));
+        assert_eq!(default_options.max_file_size, None);
+
+        // Test custom options
+        let custom_options = MediaProcessingOptions {
+            strip_exif: false,
+            preserve_dimensions: false,
+            generate_blurhash: false,
+            max_dimension: Some(1024),
+            max_file_size: Some(1024 * 1024),
+        };
+
+        assert!(!custom_options.strip_exif);
+        assert!(!custom_options.preserve_dimensions);
+        assert!(!custom_options.generate_blurhash);
+        assert_eq!(custom_options.max_dimension, Some(1024));
+        assert_eq!(custom_options.max_file_size, Some(1024 * 1024));
+    }
+
+    #[test]
+    fn test_encrypted_media_upload_structure() {
+        let upload = EncryptedMediaUpload {
+            encrypted_data: vec![1, 2, 3, 4, 5],
+            original_hash: [0x01; 32],
+            encrypted_hash: [0x02; 32],
+            mime_type: "image/webp".to_string(),
+            filename: "test.webp".to_string(),
+            original_size: 5000,
+            encrypted_size: 5016, // Original + ChaCha20-Poly1305 overhead
+            dimensions: Some((1024, 768)),
+            blurhash: Some("L6PZfSi_.AyE_3t7t7R**0o#DgR4".to_string()),
+        };
+
+        // Verify all fields are accessible
+        assert_eq!(upload.encrypted_data.len(), 5);
+        assert_eq!(upload.original_hash, [0x01; 32]);
+        assert_eq!(upload.encrypted_hash, [0x02; 32]);
+        assert_eq!(upload.mime_type, "image/webp");
+        assert_eq!(upload.filename, "test.webp");
+        assert_eq!(upload.original_size, 5000);
+        assert_eq!(upload.encrypted_size, 5016);
+        assert_eq!(upload.dimensions, Some((1024, 768)));
+        assert!(upload.blurhash.is_some());
+    }
+
+    #[test]
+    fn test_media_reference_structure() {
+        let media_ref = MediaReference {
+            url: "https://storage.example.com/abc123.enc".to_string(),
+            original_hash: [0xFF; 32],
+            mime_type: "video/mp4".to_string(),
+            filename: "test.mp4".to_string(),
+            dimensions: Some((1920, 1080)),
+        };
+
+        // Verify all fields are accessible
+        assert_eq!(media_ref.url, "https://storage.example.com/abc123.enc");
+        assert_eq!(media_ref.original_hash, [0xFF; 32]);
+        assert_eq!(media_ref.mime_type, "video/mp4");
+        assert_eq!(media_ref.filename, "test.mp4");
+        assert_eq!(media_ref.dimensions, Some((1920, 1080)));
+    }
+
+    #[test]
+    fn test_error_types() {
+        // Test that all error types can be created and formatted properly
+        let errors = vec![
+            EncryptedMediaError::FileTooLarge {
+                size: 1000,
+                max_size: 500,
+            },
+            EncryptedMediaError::UnsupportedMimeType {
+                mime_type: "application/pdf".to_string(),
+            },
+            EncryptedMediaError::InvalidMimeType {
+                mime_type: "invalid".to_string(),
+            },
+            EncryptedMediaError::FilenameTooLong {
+                length: 300,
+                max_length: 210,
+            },
+            EncryptedMediaError::EmptyFilename,
+            EncryptedMediaError::DimensionsTooLarge {
+                width: 20000,
+                height: 15000,
+                max_dimension: 16384,
+            },
+            EncryptedMediaError::EncryptionFailed {
+                reason: "Test encryption failure".to_string(),
+            },
+            EncryptedMediaError::DecryptionFailed {
+                reason: "Test decryption failure".to_string(),
+            },
+            EncryptedMediaError::MetadataExtractionFailed {
+                reason: "Test metadata failure".to_string(),
+            },
+            EncryptedMediaError::HashVerificationFailed,
+            EncryptedMediaError::GroupNotFound,
+            EncryptedMediaError::InvalidNonce,
+            EncryptedMediaError::InvalidImetaTag {
+                reason: "Test invalid tag".to_string(),
+            },
+        ];
+
+        // Verify all errors can be formatted (tests Display implementation)
+        for error in errors {
+            let error_string = format!("{}", error);
+            assert!(!error_string.is_empty());
+        }
+    }
+}

--- a/crates/mdk-core/src/encrypted_media/validation.rs
+++ b/crates/mdk-core/src/encrypted_media/validation.rs
@@ -1,0 +1,367 @@
+//! Input validation for encrypted media operations
+//!
+//! This module provides validation functions for media files, MIME types,
+//! filenames, and other input parameters to ensure they meet security
+//! and protocol requirements.
+
+use crate::encrypted_media::types::{
+    EncryptedMediaError, MediaProcessingOptions, MAX_FILENAME_LENGTH, MAX_FILE_SIZE,
+    MIME_TYPE_ALIASES, SUPPORTED_MIME_TYPES,
+};
+
+/// Validate input parameters for media encryption
+///
+/// Returns the canonical MIME type that should be used for all subsequent operations
+pub fn validate_inputs(
+    data: &[u8],
+    mime_type: &str,
+    filename: &str,
+    options: &MediaProcessingOptions,
+) -> Result<String, EncryptedMediaError> {
+    validate_file_size(data, options)?;
+    let canonical_mime_type = validate_mime_type(mime_type)?;
+    validate_filename(filename)?;
+    Ok(canonical_mime_type)
+}
+
+/// Validate file size against limits
+pub fn validate_file_size(
+    data: &[u8],
+    options: &MediaProcessingOptions,
+) -> Result<(), EncryptedMediaError> {
+    let max_size = options.max_file_size.unwrap_or(MAX_FILE_SIZE);
+    if data.len() > max_size {
+        return Err(EncryptedMediaError::FileTooLarge {
+            size: data.len(),
+            max_size,
+        });
+    }
+    Ok(())
+}
+
+/// Validate MIME type format and support
+///
+/// Returns the canonical (trimmed and lowercase) MIME type for consistent use
+/// in cryptographic operations and comparisons. Handles aliases by mapping them
+/// to their canonical forms.
+///
+/// This is the centralized function for MIME type canonicalization used throughout
+/// the encrypted media system. All MIME type processing should use this function
+/// to ensure consistency in encryption keys, AAD construction, and imeta tags.
+pub fn validate_mime_type(mime_type: &str) -> Result<String, EncryptedMediaError> {
+    // Normalize the MIME type: trim whitespace and convert to lowercase
+    let normalized = mime_type.trim().to_ascii_lowercase();
+
+    // Validate MIME type format using normalized version
+    if !normalized.contains('/') || normalized.len() > 100 {
+        return Err(EncryptedMediaError::InvalidMimeType {
+            mime_type: mime_type.to_string(),
+        });
+    }
+
+    // Check if it's an alias and map to canonical form
+    let canonical = MIME_TYPE_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == normalized)
+        .map(|(_, canonical)| canonical.to_string())
+        .unwrap_or(normalized);
+
+    // Check if canonical MIME type is supported
+    if !SUPPORTED_MIME_TYPES.contains(&canonical.as_str()) {
+        return Err(EncryptedMediaError::UnsupportedMimeType {
+            mime_type: mime_type.to_string(),
+        });
+    }
+
+    Ok(canonical)
+}
+
+/// Validate filename length and content
+pub fn validate_filename(filename: &str) -> Result<(), EncryptedMediaError> {
+    // Validate filename is not empty
+    if filename.is_empty() {
+        return Err(EncryptedMediaError::EmptyFilename);
+    }
+
+    // Validate filename length
+    if filename.len() > MAX_FILENAME_LENGTH {
+        return Err(EncryptedMediaError::FilenameTooLong {
+            length: filename.len(),
+            max_length: MAX_FILENAME_LENGTH,
+        });
+    }
+
+    // Disallow path separators and control characters
+    if filename.contains('/') || filename.contains('\\') || filename.chars().any(|c| c.is_control())
+    {
+        return Err(EncryptedMediaError::InvalidFilename);
+    }
+
+    Ok(())
+}
+
+/// Validate image dimensions against limits
+pub fn validate_image_dimensions(
+    width: u32,
+    height: u32,
+    options: &MediaProcessingOptions,
+) -> Result<(), EncryptedMediaError> {
+    if let Some(max_dim) = options.max_dimension {
+        if width > max_dim || height > max_dim {
+            return Err(EncryptedMediaError::DimensionsTooLarge {
+                width,
+                height,
+                max_dimension: max_dim,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_inputs() {
+        let options = MediaProcessingOptions::default();
+
+        // Test valid inputs
+        let data = vec![0u8; 1000];
+        let result = validate_inputs(&data, "image/jpeg", "test.jpg", &options);
+        assert_eq!(result.unwrap(), "image/jpeg");
+
+        // Test file too large
+        let large_data = vec![0u8; MAX_FILE_SIZE + 1];
+        let result = validate_inputs(&large_data, "image/jpeg", "test.jpg", &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::FileTooLarge { .. })
+        ));
+
+        // Test unsupported MIME type
+        let data = vec![0u8; 1000];
+        let result = validate_inputs(&data, "application/pdf", "test.pdf", &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::UnsupportedMimeType { .. })
+        ));
+
+        // Test invalid MIME type format
+        let result = validate_inputs(&data, "invalid", "test.jpg", &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidMimeType { .. })
+        ));
+
+        // Test filename too long
+        let long_filename = "a".repeat(MAX_FILENAME_LENGTH + 1);
+        let result = validate_inputs(&data, "image/jpeg", &long_filename, &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::FilenameTooLong { .. })
+        ));
+
+        // Test empty filename
+        let result = validate_inputs(&data, "image/jpeg", "", &options);
+        assert!(matches!(result, Err(EncryptedMediaError::EmptyFilename)));
+
+        // Test valid inputs
+        let result = validate_inputs(&data, "image/jpeg", "test.jpg", &options);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_file_size() {
+        let options = MediaProcessingOptions::default();
+
+        // Test valid size
+        let valid_data = vec![0u8; 1000];
+        assert!(validate_file_size(&valid_data, &options).is_ok());
+
+        // Test too large
+        let large_data = vec![0u8; MAX_FILE_SIZE + 1];
+        let result = validate_file_size(&large_data, &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::FileTooLarge { .. })
+        ));
+
+        // Test custom size limit
+        let custom_options = MediaProcessingOptions {
+            max_file_size: Some(500),
+            ..Default::default()
+        };
+        let result = validate_file_size(&valid_data, &custom_options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::FileTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_mime_type() {
+        // Test valid MIME types return canonical form
+        assert_eq!(validate_mime_type("image/jpeg").unwrap(), "image/jpeg");
+        assert_eq!(validate_mime_type("video/mp4").unwrap(), "video/mp4");
+        assert_eq!(validate_mime_type("audio/wav").unwrap(), "audio/wav");
+        assert_eq!(validate_mime_type("audio/mpeg").unwrap(), "audio/mpeg");
+
+        // Test canonicalization (uppercase -> lowercase)
+        assert_eq!(validate_mime_type("Image/JPEG").unwrap(), "image/jpeg");
+        assert_eq!(validate_mime_type("VIDEO/MP4").unwrap(), "video/mp4");
+        assert_eq!(validate_mime_type("Audio/WAV").unwrap(), "audio/wav");
+        assert_eq!(validate_mime_type("Audio/MPEG").unwrap(), "audio/mpeg");
+
+        // Test trimming whitespace
+        assert_eq!(validate_mime_type("  image/jpeg  ").unwrap(), "image/jpeg");
+        assert_eq!(validate_mime_type("\timage/png\n").unwrap(), "image/png");
+
+        // Test combined normalization
+        assert_eq!(validate_mime_type("  Image/WEBP  ").unwrap(), "image/webp");
+
+        // Test MIME type aliases map to canonical forms
+        assert_eq!(validate_mime_type("audio/mp3").unwrap(), "audio/mpeg");
+        assert_eq!(validate_mime_type("audio/x-wav").unwrap(), "audio/wav");
+        assert_eq!(validate_mime_type("audio/wave").unwrap(), "audio/wav");
+
+        // Test aliases with case normalization
+        assert_eq!(validate_mime_type("Audio/MP3").unwrap(), "audio/mpeg");
+        assert_eq!(validate_mime_type("AUDIO/X-WAV").unwrap(), "audio/wav");
+        assert_eq!(validate_mime_type("  audio/wave  ").unwrap(), "audio/wav");
+
+        // Test unsupported MIME type
+        let result = validate_mime_type("application/pdf");
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::UnsupportedMimeType { .. })
+        ));
+
+        // Test invalid format
+        let result = validate_mime_type("invalid");
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidMimeType { .. })
+        ));
+
+        // Test too long
+        let long_mime = "a".repeat(101);
+        let result = validate_mime_type(&long_mime);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidMimeType { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_filename() {
+        // Test valid filename
+        assert!(validate_filename("test.jpg").is_ok());
+        assert!(validate_filename("my-photo.png").is_ok());
+
+        // Test empty filename
+        let result = validate_filename("");
+        assert!(matches!(result, Err(EncryptedMediaError::EmptyFilename)));
+
+        // Test too long filename
+        let long_filename = "a".repeat(MAX_FILENAME_LENGTH + 1);
+        let result = validate_filename(&long_filename);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::FilenameTooLong { .. })
+        ));
+
+        // Test maximum length filename (should be valid)
+        let max_filename = "a".repeat(MAX_FILENAME_LENGTH);
+        assert!(validate_filename(&max_filename).is_ok());
+    }
+
+    #[test]
+    fn test_validate_image_dimensions() {
+        let options = MediaProcessingOptions::default();
+
+        // Test valid dimensions
+        assert!(validate_image_dimensions(1920, 1080, &options).is_ok());
+        assert!(validate_image_dimensions(800, 600, &options).is_ok());
+
+        // Test dimensions too large
+        let result = validate_image_dimensions(20000, 15000, &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::DimensionsTooLarge { .. })
+        ));
+
+        // Test with no dimension limit
+        let no_limit_options = MediaProcessingOptions {
+            max_dimension: None,
+            ..Default::default()
+        };
+        assert!(validate_image_dimensions(50000, 40000, &no_limit_options).is_ok());
+
+        // Test with custom dimension limit
+        let custom_options = MediaProcessingOptions {
+            max_dimension: Some(1024),
+            ..Default::default()
+        };
+        let result = validate_image_dimensions(2048, 1536, &custom_options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::DimensionsTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_inputs_comprehensive() {
+        let options = MediaProcessingOptions::default();
+
+        // Test valid inputs return canonical MIME type
+        let valid_data = vec![0u8; 1000];
+        let result = validate_inputs(&valid_data, "image/jpeg", "valid_file.jpg", &options);
+        assert_eq!(result.unwrap(), "image/jpeg");
+
+        // Test canonicalization in validate_inputs
+        let result = validate_inputs(&valid_data, "  Image/JPEG  ", "valid_file.jpg", &options);
+        assert_eq!(result.unwrap(), "image/jpeg");
+
+        // Test file too large
+        let large_data = vec![0u8; MAX_FILE_SIZE + 1];
+        let result = validate_inputs(&large_data, "image/jpeg", "large_file.jpg", &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::FileTooLarge { .. })
+        ));
+
+        // Test unsupported MIME type
+        let result = validate_inputs(&valid_data, "application/pdf", "document.pdf", &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::UnsupportedMimeType { .. })
+        ));
+
+        // Test invalid MIME type format
+        let result = validate_inputs(&valid_data, "invalid", "file.txt", &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidMimeType { .. })
+        ));
+
+        // Test filename too long
+        let long_filename = "a".repeat(MAX_FILENAME_LENGTH + 1);
+        let result = validate_inputs(&valid_data, "image/jpeg", &long_filename, &options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::FilenameTooLong { .. })
+        ));
+
+        // Test custom file size limit
+        let custom_options = MediaProcessingOptions {
+            max_file_size: Some(500),
+            ..Default::default()
+        };
+        let result = validate_inputs(&valid_data, "image/jpeg", "small_file.jpg", &custom_options);
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::FileTooLarge { .. })
+        ));
+    }
+}

--- a/crates/mdk-core/src/error.rs
+++ b/crates/mdk-core/src/error.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2025 Rust Nostr Developers
 // Distributed under the MIT software license
 
-//! Nostr MLS errors
+//! MDK errors
 
 use std::string::FromUtf8Error;
 use std::{fmt, str};
@@ -23,77 +23,112 @@ use openmls::key_packages::errors::{KeyPackageNewError, KeyPackageVerifyError};
 use openmls_traits::types::CryptoError;
 
 /// Nostr MLS error
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum Error {
     /// Hex error
-    Hex(hex::FromHexError),
+    #[error(transparent)]
+    Hex(#[from] hex::FromHexError),
     /// Keys error
-    Keys(key::Error),
+    #[error(transparent)]
+    Keys(#[from] key::Error),
     /// Event error
-    Event(event::Error),
+    #[error(transparent)]
+    Event(#[from] event::Error),
     /// Event Builder error
-    EventBuilder(event::builder::Error),
+    #[error(transparent)]
+    EventBuilder(#[from] event::builder::Error),
     /// Nostr Signer error
-    Signer(SignerError),
+    #[error(transparent)]
+    Signer(#[from] SignerError),
     /// NIP44 error
-    NIP44(nip44::Error),
+    #[error(transparent)]
+    NIP44(#[from] nip44::Error),
     /// Relay URL error
-    RelayUrl(url::Error),
+    #[error(transparent)]
+    RelayUrl(#[from] url::Error),
     /// TLS error
-    Tls(tls_codec::Error),
+    #[error(transparent)]
+    Tls(#[from] tls_codec::Error),
     /// UTF8 error
-    Utf8(str::Utf8Error),
+    #[error(transparent)]
+    Utf8(#[from] str::Utf8Error),
     /// Crypto error
-    Crypto(CryptoError),
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
     /// Generic OpenMLS error
-    OpenMlsGeneric(LibraryError),
+    #[error(transparent)]
+    OpenMlsGeneric(#[from] LibraryError),
     /// Invalid extension error
-    InvalidExtension(InvalidExtensionError),
+    #[error(transparent)]
+    InvalidExtension(#[from] InvalidExtensionError),
     /// Create message error
-    CreateMessage(CreateMessageError),
+    #[error(transparent)]
+    CreateMessage(#[from] CreateMessageError),
     /// Export secret error
-    ExportSecret(ExportSecretError),
+    #[error(transparent)]
+    ExportSecret(#[from] ExportSecretError),
     /// Basic credential error
-    BasicCredential(BasicCredentialError),
+    #[error(transparent)]
+    BasicCredential(#[from] BasicCredentialError),
     /// Process message error
-    ProcessMessage(ProcessMessageError),
+    #[error(transparent)]
+    ProcessMessage(#[from] ProcessMessageError),
     /// Protocol message error
+    #[error("{0}")]
     ProtocolMessage(String),
     /// Key package error
+    #[error("{0}")]
     KeyPackage(String),
     /// Group error
+    #[error("{0}")]
     Group(String),
     /// Group exporter secret not found
+    #[error("group exporter secret not found")]
     GroupExporterSecretNotFound,
     /// Message error
+    #[error("{0}")]
     Message(String),
     /// Cannot decrypt own message
+    #[error("cannot decrypt own message")]
     CannotDecryptOwnMessage,
     /// Merge pending commit error
+    #[error("{0}")]
     MergePendingCommit(String),
     /// Commit to pending proposal
+    #[error("unable to commit to pending proposal")]
     CommitToPendingProposalsError,
     /// Self update error
+    #[error("{0}")]
     SelfUpdate(String),
     /// Welcome error
+    #[error("{0}")]
     Welcome(String),
     /// We're missing a Welcome for an existing ProcessedWelcome
+    #[error("missing welcome for processed welcome")]
     MissingWelcomeForProcessedWelcome,
     /// Processed welcome not found
+    #[error("processed welcome not found")]
     ProcessedWelcomeNotFound,
     /// Provider error
+    #[error("{0}")]
     Provider(String),
     /// Group not found
+    #[error("group not found")]
     GroupNotFound,
     /// Protocol message group ID doesn't match the current group ID
+    #[error("protocol message group ID doesn't match the current group ID")]
     ProtocolGroupIdMismatch,
     /// Own leaf not found
+    #[error("own leaf not found")]
     OwnLeafNotFound,
     /// Failed to load signer
+    #[error("can't load signer")]
     CantLoadSigner,
     /// Invalid Welcome message
+    #[error("invalid welcome message")]
     InvalidWelcomeMessage,
     /// Unexpected event
+    #[error("unexpected event kind: expected={expected}, received={received}")]
     UnexpectedEvent {
         /// Expected event kind
         expected: Kind,
@@ -101,203 +136,43 @@ pub enum Error {
         received: Kind,
     },
     /// Unexpected extension type
+    #[error("Unexpected extension type")]
     UnexpectedExtensionType,
     /// Nostr group data extension not found
+    #[error("Nostr group data extension not found")]
     NostrGroupDataExtensionNotFound,
     /// Message from a non-member of a group
+    #[error("Message received from non-member")]
     MessageFromNonMember,
     /// Code path is not yet implemented
+    #[error("{0}")]
     NotImplemented(String),
     /// Stored message not found
+    #[error("stored message not found")]
     MessageNotFound,
     /// Proposal message received from a non-admin
+    #[error("not processing proposal from non-admin")]
     ProposalFromNonAdmin,
     /// Commit message received from a non-admin
+    #[error("not processing commit from non-admin")]
     CommitFromNonAdmin,
     /// Error when updating group context extensions
+    #[error("Error when updating group context extensions {0}")]
     UpdateGroupContextExts(String),
     /// Invalid image hash length
+    #[error("invalid image hash length")]
     InvalidImageHashLength,
     /// Invalid image key length
+    #[error("invalid image key length")]
     InvalidImageKeyLength,
     /// Invalid image nonce length
+    #[error("invalid image nonce length")]
     InvalidImageNonceLength,
-}
-
-impl std::error::Error for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Hex(e) => write!(f, "{e}"),
-            Self::Keys(e) => write!(f, "{e}"),
-            Self::Event(e) => write!(f, "{e}"),
-            Self::EventBuilder(e) => write!(f, "{e}"),
-            Self::Signer(e) => write!(f, "{e}"),
-            Self::NIP44(e) => write!(f, "{e}"),
-            Self::RelayUrl(e) => write!(f, "{e}"),
-            Self::Tls(e) => write!(f, "{e}"),
-            Self::Utf8(e) => write!(f, "{e}"),
-            Self::Crypto(e) => write!(f, "{e}"),
-            Self::OpenMlsGeneric(e) => write!(f, "{e}"),
-            Self::InvalidExtension(e) => write!(f, "{e}"),
-            Self::CreateMessage(e) => write!(f, "{e}"),
-            Self::ExportSecret(e) => write!(f, "{e}"),
-            Self::BasicCredential(e) => write!(f, "{e}"),
-            Self::ProcessMessage(e) => write!(f, "{e}"),
-            Self::ProtocolMessage(e) => write!(f, "{e}"),
-            Self::KeyPackage(e) => write!(f, "{e}"),
-            Self::Group(e) => write!(f, "{e}"),
-            Self::GroupExporterSecretNotFound => write!(f, "group exporter secret not found"),
-            Self::Message(e) => write!(f, "{e}"),
-            Self::CannotDecryptOwnMessage => write!(f, "cannot decrypt own message"),
-            Self::Welcome(e) => write!(f, "{e}"),
-            Self::MissingWelcomeForProcessedWelcome => {
-                write!(f, "missing welcome for processed welcome")
-            }
-            Self::ProcessedWelcomeNotFound => write!(f, "processed welcome not found"),
-            Self::MergePendingCommit(e) => write!(f, "{e}"),
-            Self::CommitToPendingProposalsError => {
-                write!(f, "unable to commit to pending proposal")
-            }
-            Self::SelfUpdate(e) => write!(f, "{e}"),
-            Self::Provider(e) => write!(f, "{e}"),
-            Self::GroupNotFound => write!(f, "group not found"),
-            Self::ProtocolGroupIdMismatch => write!(
-                f,
-                "protocol message group ID doesn't match the current group ID"
-            ),
-            Self::OwnLeafNotFound => write!(f, "own leaf not found"),
-            Self::CantLoadSigner => write!(f, "can't load signer"),
-            Self::InvalidWelcomeMessage => write!(f, "invalid welcome message"),
-            Self::UnexpectedEvent { expected, received } => write!(
-                f,
-                "unexpected event kind: expected={expected}, received={received}"
-            ),
-            Self::UnexpectedExtensionType => {
-                write!(f, "Unexpected extension type")
-            }
-            Self::NostrGroupDataExtensionNotFound => {
-                write!(f, "Nostr group data extension not found")
-            }
-            Self::MessageFromNonMember => {
-                write!(f, "Message recieved from non-member")
-            }
-            Self::NotImplemented(e) => {
-                write!(f, "{e}")
-            }
-            Self::MessageNotFound => write!(f, "stored message not found"),
-            Self::ProposalFromNonAdmin => write!(f, "not processing proposal from non-admin"),
-            Self::CommitFromNonAdmin => write!(f, "not processing commit from non-admin"),
-            Self::UpdateGroupContextExts(e) => {
-                write!(f, "Error when updating group context extensions {e}")
-            }
-            Self::InvalidImageHashLength => write!(f, "invalid image hash length"),
-            Self::InvalidImageKeyLength => write!(f, "invalid image key length"),
-            Self::InvalidImageNonceLength => write!(f, "invalid image nonce length"),
-        }
-    }
-}
-
-impl From<hex::FromHexError> for Error {
-    fn from(e: hex::FromHexError) -> Self {
-        Self::Hex(e)
-    }
-}
-
-impl From<key::Error> for Error {
-    fn from(e: key::Error) -> Self {
-        Self::Keys(e)
-    }
-}
-
-impl From<event::Error> for Error {
-    fn from(e: event::Error) -> Self {
-        Self::Event(e)
-    }
-}
-
-impl From<event::builder::Error> for Error {
-    fn from(e: event::builder::Error) -> Self {
-        Self::EventBuilder(e)
-    }
-}
-
-impl From<SignerError> for Error {
-    fn from(e: SignerError) -> Self {
-        Self::Signer(e)
-    }
-}
-
-impl From<nip44::Error> for Error {
-    fn from(e: nip44::Error) -> Self {
-        Self::NIP44(e)
-    }
-}
-
-impl From<url::Error> for Error {
-    fn from(e: url::Error) -> Self {
-        Self::RelayUrl(e)
-    }
-}
-
-impl From<tls_codec::Error> for Error {
-    fn from(e: tls_codec::Error) -> Self {
-        Self::Tls(e)
-    }
-}
-
-impl From<str::Utf8Error> for Error {
-    fn from(e: str::Utf8Error) -> Self {
-        Self::Utf8(e)
-    }
 }
 
 impl From<FromUtf8Error> for Error {
     fn from(e: FromUtf8Error) -> Self {
         Self::Utf8(e.utf8_error())
-    }
-}
-
-impl From<CryptoError> for Error {
-    fn from(e: CryptoError) -> Self {
-        Self::Crypto(e)
-    }
-}
-
-impl From<LibraryError> for Error {
-    fn from(e: LibraryError) -> Self {
-        Self::OpenMlsGeneric(e)
-    }
-}
-
-impl From<InvalidExtensionError> for Error {
-    fn from(e: InvalidExtensionError) -> Self {
-        Self::InvalidExtension(e)
-    }
-}
-
-impl From<CreateMessageError> for Error {
-    fn from(e: CreateMessageError) -> Self {
-        Self::CreateMessage(e)
-    }
-}
-
-impl From<ExportSecretError> for Error {
-    fn from(e: ExportSecretError) -> Self {
-        Self::ExportSecret(e)
-    }
-}
-
-impl From<BasicCredentialError> for Error {
-    fn from(e: BasicCredentialError) -> Self {
-        Self::BasicCredential(e)
-    }
-}
-
-impl From<ProcessMessageError> for Error {
-    fn from(e: ProcessMessageError) -> Self {
-        Self::ProcessMessage(e)
     }
 }
 

--- a/crates/mdk-core/src/extension/group_image.rs
+++ b/crates/mdk-core/src/extension/group_image.rs
@@ -1,0 +1,403 @@
+//! Group image encryption and decryption functionality for MIP-01
+//!
+//! This module provides cryptographic operations for group avatar images:
+//! - Encryption with ChaCha20-Poly1305 AEAD
+//! - Decryption and integrity verification
+//! - Deterministic upload keypair derivation for Blossom cleanup
+//!
+//! The encryption scheme does NOT use AAD for simplicity. Integrity is provided by:
+//! 1. SHA256 hash check of encrypted blob (detects substitution)
+//! 2. ChaCha20-Poly1305 auth tag (detects tampering/corruption)
+
+use chacha20poly1305::{
+    aead::{Aead, KeyInit},
+    ChaCha20Poly1305, Nonce,
+};
+use hkdf::Hkdf;
+use nostr::secp256k1::rand::{rngs::OsRng, RngCore};
+use sha2::{Digest, Sha256};
+
+/// Domain separation label for upload keypair derivation (MIP-01 spec)
+const UPLOAD_KEYPAIR_CONTEXT: &[u8] = b"mip01-blossom-upload-v1";
+
+/// Prepared group image data ready for upload to Blossom
+#[derive(Debug, Clone)]
+pub struct GroupImageUploadPrepared {
+    /// Encrypted image data (ready to upload to Blossom)
+    pub encrypted_data: Vec<u8>,
+    /// SHA256 hash of encrypted data (verify against Blossom response)
+    pub encrypted_hash: [u8; 32],
+    /// Encryption key (store in extension)
+    pub image_key: [u8; 32],
+    /// Encryption nonce (store in extension)
+    pub image_nonce: [u8; 12],
+    /// Derived keypair for Blossom authentication
+    pub upload_keypair: nostr::Keys,
+    /// Original image size before encryption
+    pub original_size: usize,
+}
+
+/// Group image encryption result with hash (internal type)
+#[derive(Debug, Clone)]
+struct GroupImageEncrypted {
+    /// The encrypted image data
+    encrypted_data: Vec<u8>,
+    /// SHA256 hash of encrypted data (for Blossom upload)
+    encrypted_hash: [u8; 32],
+    /// Encryption key
+    image_key: [u8; 32],
+    /// Encryption nonce
+    image_nonce: [u8; 12],
+}
+
+/// Group image encryption info from extension
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupImageEncryptionInfo {
+    /// Blossom blob hash (SHA256 of encrypted data)
+    pub image_hash: [u8; 32],
+    /// Encryption key
+    pub image_key: [u8; 32],
+    /// Encryption nonce
+    pub image_nonce: [u8; 12],
+}
+
+/// Errors that can occur during group image operations
+#[derive(Debug, thiserror::Error)]
+pub enum GroupImageError {
+    /// Encryption failed
+    #[error("Encryption failed: {reason}")]
+    EncryptionFailed {
+        /// The reason for encryption failure
+        reason: String,
+    },
+
+    /// Decryption failed
+    #[error("Decryption failed: {reason}")]
+    DecryptionFailed {
+        /// The reason for decryption failure
+        reason: String,
+    },
+
+    /// Hash verification failed
+    #[error("Hash verification failed: expected {expected}, got {actual}")]
+    HashVerificationFailed {
+        /// The expected hash value
+        expected: String,
+        /// The actual hash value
+        actual: String,
+    },
+
+    /// Upload keypair derivation failed
+    #[error("Failed to derive upload keypair: {reason}")]
+    KeypairDerivationFailed {
+        /// The reason for derivation failure
+        reason: String,
+    },
+}
+
+/// Encrypt group image with random key and nonce
+///
+/// This is an internal function used by `prepare_group_image_for_upload()`.
+/// Users should use `prepare_group_image_for_upload()` instead.
+fn encrypt_group_image(image_data: &[u8]) -> Result<GroupImageEncrypted, GroupImageError> {
+    // Generate random key and nonce
+    let mut rng = OsRng;
+    let mut image_key = [0u8; 32];
+    let mut image_nonce = [0u8; 12];
+    rng.fill_bytes(&mut image_key);
+    rng.fill_bytes(&mut image_nonce);
+
+    // Encrypt with ChaCha20-Poly1305 (no AAD per MIP-01 spec)
+    let cipher = ChaCha20Poly1305::new_from_slice(&image_key).map_err(|e| {
+        GroupImageError::EncryptionFailed {
+            reason: format!("Failed to create cipher: {}", e),
+        }
+    })?;
+
+    let nonce = Nonce::from_slice(&image_nonce);
+    let encrypted_data = cipher.encrypt(nonce, image_data).map_err(|e| {
+        GroupImageError::EncryptionFailed {
+            reason: format!("Encryption failed: {}", e),
+        }
+    })?;
+
+    // Calculate hash of encrypted data
+    let encrypted_hash: [u8; 32] = Sha256::digest(&encrypted_data).into();
+
+    Ok(GroupImageEncrypted {
+        encrypted_data,
+        encrypted_hash,
+        image_key,
+        image_nonce,
+    })
+}
+
+/// Decrypt group image using extension data
+///
+/// Decrypts the encrypted blob using ChaCha20-Poly1305 AEAD. The auth tag
+/// automatically verifies integrity - if tampering occurred, decryption will fail.
+///
+/// # Arguments
+/// * `encrypted_data` - Encrypted blob downloaded from Blossom
+/// * `image_key` - Encryption key from group extension
+/// * `image_nonce` - Encryption nonce from group extension
+///
+/// # Returns
+/// * Decrypted image bytes
+///
+/// # Errors
+/// * `DecryptionFailed` - If auth tag verification fails (tampering detected)
+///
+/// # Example
+/// ```ignore
+/// let extension = mdk.get_group_extension(&group_id)?;
+/// if let Some(info) = extension.group_image_encryption_data() {
+///     let encrypted_blob = download_from_blossom(&info.image_hash).await?;
+///     let image = decrypt_group_image(&encrypted_blob, &info.image_key, &info.image_nonce)?;
+/// }
+/// ```
+pub fn decrypt_group_image(
+    encrypted_data: &[u8],
+    image_key: &[u8; 32],
+    image_nonce: &[u8; 12],
+) -> Result<Vec<u8>, GroupImageError> {
+    let cipher = ChaCha20Poly1305::new_from_slice(image_key).map_err(|e| {
+        GroupImageError::DecryptionFailed {
+            reason: format!("Failed to create cipher: {}", e),
+        }
+    })?;
+
+    let nonce = Nonce::from_slice(image_nonce);
+    let decrypted_data = cipher.decrypt(nonce, encrypted_data).map_err(|e| {
+        GroupImageError::DecryptionFailed {
+            reason: format!("Decryption failed (possible tampering): {}", e),
+        }
+    })?;
+
+    Ok(decrypted_data)
+}
+
+/// Derive Blossom upload keypair from image_key
+///
+/// Uses HKDF-Expand with the context "mip01-blossom-upload-v1" to deterministically
+/// derive a Nostr keypair from the image encryption key. This enables cleanup of old
+/// images - anyone with the image_key can derive the upload keypair and delete the blob.
+///
+/// # Arguments
+/// * `image_key` - The 32-byte image encryption key
+///
+/// # Returns
+/// * Nostr keypair for Blossom authentication
+///
+/// # Example
+/// ```ignore
+/// // Cleanup old image after updating
+/// if let Some(old_info) = old_extension.group_image_encryption_data() {
+///     let old_keypair = derive_upload_keypair(&old_info.image_key)?;
+///     blossom_client.delete(&old_info.image_hash, &old_keypair).await?;
+/// }
+/// ```
+pub fn derive_upload_keypair(image_key: &[u8; 32]) -> Result<nostr::Keys, GroupImageError> {
+    // Use HKDF-Expand to derive upload secret from image_key
+    let hk = Hkdf::<Sha256>::new(None, image_key);
+    let mut upload_secret = [0u8; 32];
+
+    hk.expand(UPLOAD_KEYPAIR_CONTEXT, &mut upload_secret)
+        .map_err(|e| GroupImageError::KeypairDerivationFailed {
+            reason: format!("HKDF expansion failed: {}", e),
+        })?;
+
+    // Create Nostr keypair from derived secret
+    let secret_key = nostr::SecretKey::from_slice(&upload_secret).map_err(|e| {
+        GroupImageError::KeypairDerivationFailed {
+            reason: format!("Invalid secret key: {}", e),
+        }
+    })?;
+
+    Ok(nostr::Keys::new(secret_key))
+}
+
+/// Prepare group image for upload (encrypt + derive keypair)
+///
+/// This is a convenience function that encrypts the image and derives the upload keypair
+/// in one step, returning everything needed for the upload workflow.
+///
+/// # Arguments
+/// * `image_data` - Raw image bytes
+///
+/// # Returns
+/// * `GroupImageUploadPrepared` with encrypted data, hash, and upload keypair
+///
+/// # Example
+/// ```ignore
+/// let prepared = prepare_group_image_for_upload(&image_bytes)?;
+///
+/// // Upload to Blossom
+/// let blob_hash = blossom_client.upload(
+///     &prepared.encrypted_data,
+///     &prepared.upload_keypair
+/// ).await?;
+///
+/// // Verify the Blossom response matches our hash
+/// assert_eq!(blob_hash, prepared.encrypted_hash);
+///
+/// // Update extension with the verified hash
+/// let update = NostrGroupDataUpdate::new()
+///     .image_hash(Some(blob_hash))
+///     .image_key(Some(prepared.image_key))
+///     .image_nonce(Some(prepared.image_nonce));
+/// ```
+pub fn prepare_group_image_for_upload(
+    image_data: &[u8],
+) -> Result<GroupImageUploadPrepared, GroupImageError> {
+    let encrypted = encrypt_group_image(image_data)?;
+    let upload_keypair = derive_upload_keypair(&encrypted.image_key)?;
+
+    Ok(GroupImageUploadPrepared {
+        encrypted_data: encrypted.encrypted_data,
+        encrypted_hash: encrypted.encrypted_hash,
+        image_key: encrypted.image_key,
+        image_nonce: encrypted.image_nonce,
+        upload_keypair,
+        original_size: image_data.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let original_data = b"This is a test group avatar image";
+
+        // Encrypt
+        let encrypted = encrypt_group_image(original_data).unwrap();
+        assert_ne!(encrypted.encrypted_data.as_slice(), original_data);
+        assert!(encrypted.encrypted_data.len() > original_data.len()); // Includes auth tag
+
+        // Decrypt
+        let decrypted = decrypt_group_image(
+            &encrypted.encrypted_data,
+            &encrypted.image_key,
+            &encrypted.image_nonce,
+        )
+        .unwrap();
+
+        assert_eq!(decrypted.as_slice(), original_data);
+    }
+
+    #[test]
+    fn test_decrypt_with_wrong_key() {
+        let original_data = b"Test image data";
+        let encrypted = encrypt_group_image(original_data).unwrap();
+
+        let wrong_key = [0x42u8; 32];
+        let result = decrypt_group_image(
+            &encrypted.encrypted_data,
+            &wrong_key,
+            &encrypted.image_nonce,
+        );
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(GroupImageError::DecryptionFailed { .. })));
+    }
+
+    #[test]
+    fn test_decrypt_with_wrong_nonce() {
+        let original_data = b"Test image data";
+        let encrypted = encrypt_group_image(original_data).unwrap();
+
+        let wrong_nonce = [0x24u8; 12];
+        let result = decrypt_group_image(
+            &encrypted.encrypted_data,
+            &encrypted.image_key,
+            &wrong_nonce,
+        );
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(GroupImageError::DecryptionFailed { .. })));
+    }
+
+    #[test]
+    fn test_derive_upload_keypair_deterministic() {
+        let image_key = [0x42u8; 32];
+
+        let keypair1 = derive_upload_keypair(&image_key).unwrap();
+        let keypair2 = derive_upload_keypair(&image_key).unwrap();
+
+        // Same key should derive same keypair
+        assert_eq!(keypair1.public_key(), keypair2.public_key());
+        // Both should have the same secret key bytes
+        assert_eq!(
+            keypair1.secret_key().as_secret_bytes(),
+            keypair2.secret_key().as_secret_bytes()
+        );
+    }
+
+    #[test]
+    fn test_derive_upload_keypair_different_keys() {
+        let key1 = [0x42u8; 32];
+        let key2 = [0x43u8; 32];
+
+        let keypair1 = derive_upload_keypair(&key1).unwrap();
+        let keypair2 = derive_upload_keypair(&key2).unwrap();
+
+        // Different keys should derive different keypairs
+        assert_ne!(keypair1.public_key(), keypair2.public_key());
+    }
+
+    #[test]
+    fn test_prepare_group_image_for_upload() {
+        let image_data = b"Test group avatar";
+
+        let prepared = prepare_group_image_for_upload(image_data).unwrap();
+
+        // Verify all fields are populated
+        assert!(!prepared.encrypted_data.is_empty());
+        assert_eq!(prepared.original_size, image_data.len());
+
+        // Verify the encrypted hash matches the actual hash
+        let calculated_hash: [u8; 32] = Sha256::digest(&prepared.encrypted_data).into();
+        assert_eq!(prepared.encrypted_hash, calculated_hash);
+
+        // Verify we can decrypt
+        let decrypted =
+            decrypt_group_image(&prepared.encrypted_data, &prepared.image_key, &prepared.image_nonce)
+                .unwrap();
+        assert_eq!(decrypted.as_slice(), image_data);
+
+        // Verify keypair derivation is correct
+        let derived_keypair = derive_upload_keypair(&prepared.image_key).unwrap();
+        assert_eq!(
+            derived_keypair.public_key(),
+            prepared.upload_keypair.public_key()
+        );
+    }
+
+    #[test]
+    fn test_encrypted_hash_calculation() {
+        let image_data = b"Test data for hash";
+        let encrypted = encrypt_group_image(image_data).unwrap();
+
+        // Verify hash matches
+        let calculated_hash: [u8; 32] = Sha256::digest(&encrypted.encrypted_data).into();
+        assert_eq!(calculated_hash, encrypted.encrypted_hash);
+    }
+
+    #[test]
+    fn test_tampering_detection() {
+        let original_data = b"Original group image";
+        let encrypted = encrypt_group_image(original_data).unwrap();
+
+        // Tamper with encrypted data
+        let mut tampered = encrypted.encrypted_data.clone();
+        tampered[0] ^= 0xFF;
+
+        // Decryption should fail
+        let result = decrypt_group_image(&tampered, &encrypted.image_key, &encrypted.image_nonce);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(GroupImageError::DecryptionFailed { .. })));
+    }
+
+}

--- a/crates/mdk-core/src/extension/group_image.rs
+++ b/crates/mdk-core/src/extension/group_image.rs
@@ -115,11 +115,12 @@ fn encrypt_group_image(image_data: &[u8]) -> Result<GroupImageEncrypted, GroupIm
     })?;
 
     let nonce = Nonce::from_slice(&image_nonce);
-    let encrypted_data = cipher.encrypt(nonce, image_data).map_err(|e| {
-        GroupImageError::EncryptionFailed {
-            reason: format!("Encryption failed: {}", e),
-        }
-    })?;
+    let encrypted_data =
+        cipher
+            .encrypt(nonce, image_data)
+            .map_err(|e| GroupImageError::EncryptionFailed {
+                reason: format!("Encryption failed: {}", e),
+            })?;
 
     // Calculate hash of encrypted data
     let encrypted_hash: [u8; 32] = Sha256::digest(&encrypted_data).into();
@@ -168,11 +169,12 @@ pub fn decrypt_group_image(
     })?;
 
     let nonce = Nonce::from_slice(image_nonce);
-    let decrypted_data = cipher.decrypt(nonce, encrypted_data).map_err(|e| {
-        GroupImageError::DecryptionFailed {
-            reason: format!("Decryption failed (possible tampering): {}", e),
-        }
-    })?;
+    let decrypted_data =
+        cipher
+            .decrypt(nonce, encrypted_data)
+            .map_err(|e| GroupImageError::DecryptionFailed {
+                reason: format!("Decryption failed (possible tampering): {}", e),
+            })?;
 
     Ok(decrypted_data)
 }
@@ -300,7 +302,10 @@ mod tests {
         );
 
         assert!(result.is_err());
-        assert!(matches!(result, Err(GroupImageError::DecryptionFailed { .. })));
+        assert!(matches!(
+            result,
+            Err(GroupImageError::DecryptionFailed { .. })
+        ));
     }
 
     #[test]
@@ -316,7 +321,10 @@ mod tests {
         );
 
         assert!(result.is_err());
-        assert!(matches!(result, Err(GroupImageError::DecryptionFailed { .. })));
+        assert!(matches!(
+            result,
+            Err(GroupImageError::DecryptionFailed { .. })
+        ));
     }
 
     #[test]
@@ -362,9 +370,12 @@ mod tests {
         assert_eq!(prepared.encrypted_hash, calculated_hash);
 
         // Verify we can decrypt
-        let decrypted =
-            decrypt_group_image(&prepared.encrypted_data, &prepared.image_key, &prepared.image_nonce)
-                .unwrap();
+        let decrypted = decrypt_group_image(
+            &prepared.encrypted_data,
+            &prepared.image_key,
+            &prepared.image_nonce,
+        )
+        .unwrap();
         assert_eq!(decrypted.as_slice(), image_data);
 
         // Verify keypair derivation is correct
@@ -397,7 +408,9 @@ mod tests {
         // Decryption should fail
         let result = decrypt_group_image(&tampered, &encrypted.image_key, &encrypted.image_nonce);
         assert!(result.is_err());
-        assert!(matches!(result, Err(GroupImageError::DecryptionFailed { .. })));
+        assert!(matches!(
+            result,
+            Err(GroupImageError::DecryptionFailed { .. })
+        ));
     }
-
 }

--- a/crates/mdk-core/src/extension/mod.rs
+++ b/crates/mdk-core/src/extension/mod.rs
@@ -1,0 +1,18 @@
+//! MLS Group Context Extension for Nostr Groups (MIP-01)
+//!
+//! This module provides the Marmot Group Data Extension and related functionality:
+//! - Extension types for storing group metadata in MLS
+//! - Group image encryption/decryption for avatars
+//! - Blossom upload keypair derivation for cleanup
+
+pub mod group_image;
+pub mod types;
+
+// Re-export main extension types
+pub use types::NostrGroupDataExtension;
+
+// Re-export group image types and functions
+pub use group_image::{
+    decrypt_group_image, derive_upload_keypair, prepare_group_image_for_upload,
+    GroupImageEncryptionInfo, GroupImageError, GroupImageUploadPrepared,
+};

--- a/crates/mdk-core/src/extension/types.rs
+++ b/crates/mdk-core/src/extension/types.rs
@@ -1,7 +1,3 @@
-// Copyright (c) 2024-2025 Jeff Gardner
-// Copyright (c) 2025 Rust Nostr Developers
-// Distributed under the MIT software license
-
 //! Nostr Group Extension functionality for MLS Group Context.
 //! This is a required extension for Nostr Groups as per NIP-104.
 
@@ -332,6 +328,35 @@ impl NostrGroupDataExtension {
     /// * `image_nonce` - The new image encryption key (optional)
     pub fn set_image_nonce(&mut self, image_nonce: Option<[u8; 12]>) {
         self.image_nonce = image_nonce;
+    }
+
+    /// Get group image encryption data if all three fields are set
+    ///
+    /// Returns `Some` only when image_hash, image_key, and image_nonce are all present.
+    /// This ensures you have all necessary data to download and decrypt the group image.
+    ///
+    /// # Example
+    /// ```ignore
+    /// if let Some(info) = extension.group_image_encryption_data() {
+    ///     let encrypted_blob = download_from_blossom(&info.image_hash).await?;
+    ///     let image = group_image::decrypt_group_image(
+    ///         &encrypted_blob,
+    ///         &info.image_key,
+    ///         &info.image_nonce
+    ///     )?;
+    /// }
+    /// ```
+    pub fn group_image_encryption_data(&self) -> Option<crate::extension::group_image::GroupImageEncryptionInfo> {
+        match (self.image_hash, self.image_key, self.image_nonce) {
+            (Some(hash), Some(key), Some(nonce)) => {
+                Some(crate::extension::group_image::GroupImageEncryptionInfo {
+                    image_hash: hash,
+                    image_key: key,
+                    image_nonce: nonce,
+                })
+            }
+            _ => None,
+        }
     }
 
     pub(crate) fn as_raw(&self) -> TlsNostrGroupDataExtension {

--- a/crates/mdk-core/src/extension/types.rs
+++ b/crates/mdk-core/src/extension/types.rs
@@ -346,7 +346,9 @@ impl NostrGroupDataExtension {
     ///     )?;
     /// }
     /// ```
-    pub fn group_image_encryption_data(&self) -> Option<crate::extension::group_image::GroupImageEncryptionInfo> {
+    pub fn group_image_encryption_data(
+        &self,
+    ) -> Option<crate::extension::group_image::GroupImageEncryptionInfo> {
         match (self.image_hash, self.image_key, self.image_nonce) {
             (Some(hash), Some(key), Some(nonce)) => {
                 Some(crate::extension::group_image::GroupImageEncryptionInfo {

--- a/crates/mdk-core/src/lib.rs
+++ b/crates/mdk-core/src/lib.rs
@@ -15,6 +15,9 @@ use openmls::prelude::*;
 use openmls_rust_crypto::RustCrypto;
 
 mod constant;
+#[cfg(feature = "mip04")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mip04")))]
+pub mod encrypted_media;
 pub mod error;
 pub mod extension;
 pub mod groups;

--- a/docs/mls/draft-ietf-mls-extensions-08.txt
+++ b/docs/mls/draft-ietf-mls-extensions-08.txt
@@ -1,0 +1,2072 @@
+
+
+
+
+Messaging Layer Security                                       R. Robert
+Internet-Draft                                               Phoenix R&D
+Intended status: Standards Track                            21 July 2025
+Expires: 22 January 2026
+
+
+             The Messaging Layer Security (MLS) Extensions
+                      draft-ietf-mls-extensions-08
+
+Abstract
+
+   The Messaging Layer Security (MLS) protocol is an asynchronous group
+   authenticated key exchange protocol.  MLS provides a number of
+   capabilities to applications, as well as several extension points
+   internal to the protocol.  This document provides a consolidated
+   application API, guidance for how the protocol's extension points
+   should be used, and a few concrete examples of both core protocol
+   extensions and uses of the application API.
+
+About This Document
+
+   This note is to be removed before publishing as an RFC.
+
+   The latest revision of this draft can be found at
+   https://mlswg.github.io/mls-extensions/draft-ietf-mls-
+   extensions.html.  Status information for this document may be found
+   at https://datatracker.ietf.org/doc/draft-ietf-mls-extensions/.
+
+   Discussion of this document takes place on the Messaging Layer
+   Security Working Group mailing list (mailto:mls@ietf.org), which is
+   archived at https://mailarchive.ietf.org/arch/browse/mls/.  Subscribe
+   at https://www.ietf.org/mailman/listinfo/mls/.
+
+   Source for this draft and an issue tracker can be found at
+   https://github.com/mlswg/mls-extensions.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+
+
+
+
+
+Robert                   Expires 22 January 2026                [Page 1]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 22 January 2026.
+
+Copyright Notice
+
+   Copyright (c) 2025 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Conventions and Definitions . . . . . . . . . . . . . . . . .   5
+   3.  Developing Extensions for the MLS Protocol  . . . . . . . . .   5
+   4.  The Safe Application Interface  . . . . . . . . . . . . . . .   5
+     4.1.  Component IDs . . . . . . . . . . . . . . . . . . . . . .   6
+     4.2.  Hybrid Public Key Encryption (HPKE) Keys  . . . . . . . .   7
+     4.3.  Signature Keys  . . . . . . . . . . . . . . . . . . . . .   8
+     4.4.  Exported Secrets  . . . . . . . . . . . . . . . . . . . .   9
+     4.5.  Pre-Shared Keys (PSKs)  . . . . . . . . . . . . . . . . .   9
+     4.6.  Attaching Application Data to MLS Messages  . . . . . . .  10
+     4.7.  Updating Application Data in the GroupContext . . . . . .  11
+     4.8.  Attaching Application Data to a Commit  . . . . . . . . .  14
+     4.9.  Safe Additional Authenticated Data (AAD)  . . . . . . . .  15
+   5.  Negotiating Extensions and Components . . . . . . . . . . . .  16
+     5.1.  GREASE  . . . . . . . . . . . . . . . . . . . . . . . . .  17
+   6.  Extensions  . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     6.1.  AppAck  . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     6.2.  Content Advertisement . . . . . . . . . . . . . . . . . .  19
+       6.2.1.  Description . . . . . . . . . . . . . . . . . . . . .  19
+       6.2.2.  Syntax  . . . . . . . . . . . . . . . . . . . . . . .  20
+       6.2.3.  Expected Behavior . . . . . . . . . . . . . . . . . .  21
+       6.2.4.  Framing of application_data . . . . . . . . . . . . .  21
+     6.3.  SelfRemove Proposal . . . . . . . . . . . . . . . . . . .  22
+       6.3.1.  Proposal Description  . . . . . . . . . . . . . . . .  22
+     6.4.  Last resort KeyPackages . . . . . . . . . . . . . . . . .  24
+
+
+
+Robert                   Expires 22 January 2026                [Page 2]
+
+Internet-Draft                     MLS                         July 2025
+
+
+       6.4.1.  Description . . . . . . . . . . . . . . . . . . . . .  24
+       6.4.2.  Format  . . . . . . . . . . . . . . . . . . . . . . .  24
+     6.5.  Multi-Credentials . . . . . . . . . . . . . . . . . . . .  25
+       6.5.1.  Credential Bindings . . . . . . . . . . . . . . . . .  25
+       6.5.2.  Verifying a Multi-Credential  . . . . . . . . . . . .  26
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  27
+     7.1.  MLS Wire Formats  . . . . . . . . . . . . . . . . . . . .  27
+     7.2.  MLS Extension Types . . . . . . . . . . . . . . . . . . .  27
+       7.2.1.  app_data_dictionary MLS Extension . . . . . . . . . .  27
+       7.2.2.  supported_wire_formats MLS Extension  . . . . . . . .  27
+       7.2.3.  required_wire_formats MLS Extension . . . . . . . . .  28
+     7.3.  MLS Proposal Types  . . . . . . . . . . . . . . . . . . .  28
+       7.3.1.  AppDataUpdate Proposal  . . . . . . . . . . . . . . .  28
+       7.3.2.  AppEphemeral Proposal . . . . . . . . . . . . . . . .  29
+       7.3.3.  SelfRemove Proposal . . . . . . . . . . . . . . . . .  29
+       7.3.4.  AppAck Proposal . . . . . . . . . . . . . . . . . . .  29
+     7.4.  MLS Credential Types  . . . . . . . . . . . . . . . . . .  30
+       7.4.1.  Multi Credential  . . . . . . . . . . . . . . . . . .  30
+       7.4.2.  Weak Multi Credential . . . . . . . . . . . . . . . .  30
+       7.4.3.  CredentialBindingTBS  . . . . . . . . . . . . . . . .  30
+     7.5.  MLS Component Types . . . . . . . . . . . . . . . . . . .  30
+   8.  Security considerations . . . . . . . . . . . . . . . . . . .  32
+     8.1.  Safe Application API  . . . . . . . . . . . . . . . . . .  32
+     8.2.  AppAck  . . . . . . . . . . . . . . . . . . . . . . . . .  33
+     8.3.  Content Advertisement . . . . . . . . . . . . . . . . . .  34
+     8.4.  SelfRemove  . . . . . . . . . . . . . . . . . . . . . . .  34
+     8.5.  Multi Credentials . . . . . . . . . . . . . . . . . . . .  34
+   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  34
+     9.1.  Normative References  . . . . . . . . . . . . . . . . . .  34
+     9.2.  Informative References  . . . . . . . . . . . . . . . . .  35
+   Appendix A.  Change Log . . . . . . . . . . . . . . . . . . . . .  36
+   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  37
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  37
+
+1.  Introduction
+
+   This document defines extensions to MLS [RFC9420] that are not part
+   of the main protocol specification, and uses them to explain how to
+   extend the core operation of the MLS protocol.  It also describes how
+   applications can safely interact with MLS to take advantage of
+   security features of MLS.
+
+   The MLS protocol is designed to be integrated into applications in
+   order to provide security services that the application requires.
+   There are two questions to answer when designing such an integration:
+
+   1.  How does the application provide the services that MLS requires?
+
+
+
+
+Robert                   Expires 22 January 2026                [Page 3]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   2.  How does the application use MLS to get security benefits?
+
+   The MLS Architecture [I-D.ietf-mls-architecture] describes the
+   requirements for the first of these questions, namely the structure
+   of the Delivery Service and Authentication Service that MLS requires.
+   The next section of this document focuses on the second question.
+
+   MLS itself offers some basic functions that applications can use,
+   such as the secure message encapsulation (PrivateMessage), the MLS
+   exporter, and the epoch authenticator.  Current MLS applications make
+   use of these mechanisms to achieve a variety of confidentiality and
+   authentication properties.
+
+   As application designers become familiar with MLS, there is interest
+   in leveraging other cryptographic tools that an MLS group provides:
+
+   *  HPKE (Hybrid Public Key Encryption [RFC9180]) and signature key
+      pairs for each member, where the private key is known only to that
+      member, and the public key is authenticated to the other members.
+
+   *  A pre-shared key mechanism that can allow an application to inject
+      data into the MLS key schedule.
+
+   *  An exporter mechanism that allows applications to derive secrets
+      from the MLS key schedule.
+
+   *  Association of data with Commits as a synchronization mechanism.
+
+   *  Binding of information to the GroupContext to confirm group
+      agreement.
+
+   There is also interest in exposing an MLS group to multiple loosely
+   coordinated components of an application.  To accommodate such cases,
+   the above mechanisms need to be exposed in such a way that the usage
+   of different components do not conflict with each other, or with MLS
+   itself.
+
+   This document defines a set of mechanisms that application components
+   can use to ensure that their use of these facilities is properly
+   domain-separated from MLS itself, and from other application
+   components that might be using the same MLS group.
+
+
+
+
+
+
+
+
+
+
+Robert                   Expires 22 January 2026                [Page 4]
+
+Internet-Draft                     MLS                         July 2025
+
+
+2.  Conventions and Definitions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+   This document makes heavy use of the terminology and the names of
+   structs in the MLS specification [RFC9420].  In addition, we
+   introduce the following new terms:
+
+   Application:  The system that instantiates, manages, and uses an MLS
+      group.  Each MLS group is used by exactly one application, but an
+      application may maintain multiple groups.
+
+   Application component:  A subsystem of an application that has access
+      to an MLS group.
+
+   Component ID:  An identifier for an application component.  These
+      identifiers are assigned by the application.
+
+3.  Developing Extensions for the MLS Protocol
+
+   MLS is highly extensible and was designed to be used in a variety of
+   different applications.  As such, it is important to separate
+   extensions that change the behavior of an MLS stack, and application
+   usages of MLS that just take advantage of features of MLS or specific
+   extensions (hereafter referred to as _components_).  Furthermore, it
+   is essential that application components do not change the security
+   properties of MLS or require new security analysis of the MLS
+   protocol itself.
+
+4.  The Safe Application Interface
+
+   The mechanisms in this section take MLS mechanisms that are either
+   not inherently designed to be used by applications, or not inherently
+   designed to be used by multiple application components, and adds a
+   domain separator that separates application usage from MLS usage, and
+   application components' usage from each other:
+
+   *  Public-key encryption operations are tagged so that encrypted data
+      will only decrypt in the context of a given component.
+
+   *  Signing operations are similarly tagged so that signatures will
+      only verify in the context of a given component.
+
+
+
+
+
+Robert                   Expires 22 January 2026                [Page 5]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   *  Exported values include an identifier for the component to which
+      they are being exported, so that different components will get
+      different exported values.
+
+   *  Pre-shared keys are identified as originating from a specific
+      component, so that different components' contributions to the MLS
+      key schedule will not collide.
+
+   *  Additional Authenticated Data (AAD) can be domain separated by
+      component.
+
+   Similarly, the content of application messages (application_data) can
+   be distinguished and routed to different parts of an application
+   according to the media type of that content using the content
+   negotiation mechanism defined in Section 6.2.
+
+   We also define new general mechanisms that allow applications to take
+   advantage of the extensibility mechanisms of MLS without having to
+   define extensions themselves:
+
+   *  An app_data_dictionary extension type that associates application
+      data with MLS messages or with the state of the group.
+
+   *  An AppEphemeral proposal type that enables arbitrary application
+      data to be associated with a Commit.
+
+   *  An AppDataUpdate proposal type that enables efficient updates to
+      an app_data_dictionary GroupContext extension.
+
+   As with the above, information carried in these proposals and
+   extensions is marked as belonging to a specific application
+   component, so that components can manage their information
+   independently.
+
+   The separation between components is achieved by the application
+   assigning each component a unique component ID number.  These numbers
+   are then incorporated into the appropriate calculations in the
+   protocol to achieve the required separation.
+
+4.1.  Component IDs
+
+   A component ID is a four-byte value that uniquely identifies a
+   component within the scope of an application.
+
+   uint32 ComponentID;
+
+
+
+
+
+
+Robert                   Expires 22 January 2026                [Page 6]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   When a label is required for an operation, the following data
+   structure is used.  The base_label field is always the fixed string
+   "Application".  The component_id field identifies the component
+   performing the operation.  The label field identifies the operation
+   being performed.
+
+   struct {
+     opaque base_label<V>; /* = "Application" */
+     ComponentID component_id;
+     opaque label<V>;
+   } ComponentOperationLabel;
+
+4.2.  Hybrid Public Key Encryption (HPKE) Keys
+
+   This component of the API allows components to make use of the HPKE
+   key pairs generated by MLS.  A component identified by a ComponentID
+   can use any HPKE key pair for any operation defined in [RFC9180],
+   such as encryption, exporting keys, and the PSK mode, as long as the
+   info input to Setup<MODE>S and Setup<MODE>R is set to
+   ComponentOperationLabel with component_id set to the appropriate
+   ComponentID.  The context can be set to an arbitrary Context
+   specified by the application designer and can be empty if not needed.
+   For example, a component can use a key pair PublicKey, PrivateKey to
+   encrypt data as follows:
+
+   SafeEncryptWithLabel(PublicKey, ComponentID, Label, Context, Plaintext) =
+     EncryptWithLabel(PublicKey, ComponentOperationLabel, Context, Plaintext)
+
+   SafeDecryptWithLabel(PrivateKey, ComponentID, Label, Context, KEMOutput,
+     Ciphertext) =
+     DecryptWithLabel(PrivateKey, ComponentOperationLabel, Context,
+       KEMOutput, Ciphertext)
+
+   Where the fields of ComponentOperationLabel are set to
+
+   component_id = ComponentID
+   label = Label
+
+   For operations involving the secret key, ComponentID MUST be set to
+   the ComponentID of the component performing the operation, and not to
+   the ID of any other component.  In particular, this means that a
+   component cannot decrypt data meant for another component, while
+   components can encrypt data that other components can decrypt.
+
+
+
+
+
+
+
+
+Robert                   Expires 22 January 2026                [Page 7]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   In general, a ciphertext encrypted with a PublicKey can be decrypted
+   by any entity who has the corresponding PrivateKey at a given point
+   in time according to the MLS protocol (or application component).
+   For convenience, the following list summarizes lifetimes of MLS key
+   pairs.
+
+   *  The key pair of a non-blank ratchet tree node.  The PrivateKey of
+      such a key pair is known to all members in the node’s subtree.  In
+      particular, a PrivateKey of a leaf node is known only to the
+      member in that leaf.  A member in the subtree stores the
+      PrivateKey for a number of epochs, as long as the PublicKey does
+      not change.  The key pair of the root node SHOULD NOT be used,
+      since the external key pair recalled below gives better security.
+
+   *  The external_priv, external_pub key pair used for external
+      initialization.  The external_priv key is known to all group
+      members in the current epoch.  A member stores external_priv only
+      for the current epoch.  Using this key pair gives better security
+      guarantees than using the key pair of the root of the ratchet tree
+      and should always be preferred.
+
+   *  The init_key in a KeyPackage and the corresponding secret key.
+      The secret key is known only to the owner of the KeyPackage and is
+      deleted immediately after it is used to join a group.
+
+4.3.  Signature Keys
+
+   MLS session states contain a number of signature keys including the
+   ones in the LeafNode structs.  Application components can safely sign
+   content and verify signatures using these keys via the
+   SafeSignWithLabel and SafeVerifyWithLabel functions, respectively,
+   much like how the basic MLS protocol uses SignWithLabel and
+   VerifyWithLabel.
+
+   In more detail, a component identified by ComponentID should sign and
+   verify using:
+
+   SafeSignWithLabel(SignatureKey, ComponentID, Label, Content) =
+     SignWithLabel(SignatureKey, ComponentOperationLabel, Content)
+
+   SafeVerifyWithLabel(VerificationKey, ComponentID, Label, Content,
+     SignatureValue) =
+     VerifyWithLabel(VerificationKey, ComponentOperationLabel, Content,
+     SignatureValue)
+
+   Where the fields of ComponentOperationLabel are set to
+
+
+
+
+
+Robert                   Expires 22 January 2026                [Page 8]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   component_id = ComponentID
+   label = Label
+
+   For signing operations, the ComponentID MUST be set to the
+   ComponentID of the component performing the signature, and not to the
+   ID of any other component.  This means that a component cannot
+   produce signatures in place of other component.  However, components
+   can verify signatures computed by other components.  Domain
+   separation is ensured by explicitly including the ComponentID with
+   every operation.
+
+4.4.  Exported Secrets
+
+   The MLS Exporter functionality described in Section 8.5 of [RFC9420]
+   does not provide forward security for exported secrets, because the
+   exporter_secret is not deleted after a secret has been derived.  In
+   this section, we define a forward-secure exporter for use by
+   application components.
+
+   The safe exporter is constructed from an Exporter Tree, tree of
+   secrets with the same structure as the Secret Tree defined in
+   Section 9 of [RFC9420], with two differences: First, an Exporter Tree
+   always has 2^16 leaves, corresponding to the 16 bits of a ComponentID
+   value.  (As with the Secret Tree, the nodes of the tree can be
+   generated on-demand, for space-efficiency.)  Second, the root of the
+   Exporter Tree is the application_export_secret, an additional secret
+   derived from the epoch_secret at the beginning of the epoch in the
+   same way as the other secrets listed in Table 4 of [RFC9420] using
+   the label "application_export".
+
+   This tree defines one exported secret per ComponentID.  The secret
+   for a ComponentID is the tree_node_secret at the leaf node for that
+   ComponentID:
+
+SafeExportSecret(ComponentID) = tree_node_[LeafIndex(ComponentID)]_secret
+
+   Upon generating an exported secret for a component, the MLS
+   implementation MUST regard that component's exported secret as
+   "consumed", and delete any source key material according to the
+   deletion schedule in Section 9.2 of [RFC9420].
+
+4.5.  Pre-Shared Keys (PSKs)
+
+   PSKs represent key material that is injected into the MLS key
+   schedule when creating or processing a commit as defined in
+   Section 8.4 of [RFC9420].  Its injection into the key schedule means
+   that all group members have to agree on the value of the PSK.
+
+
+
+
+Robert                   Expires 22 January 2026                [Page 9]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   While PSKs are typically cryptographic keys which due to their
+   properties add to the overall security of the group, the PSK
+   mechanism can also be used to ensure that all members of a group
+   agree on arbitrary pieces of data represented as octet strings
+   (without the necessity of sending the data itself over the wire).
+   For example, a component can use the PSK mechanism to enforce that
+   all group members have access to and agree on a password or a shared
+   file.
+
+   This is achieved by creating a new epoch via a PSK proposal.
+   Transitioning to the new epoch requires using the information agreed
+   upon.
+
+   To facilitate using PSKs safely, this document defines a new PSKType
+   for application components.  This provides domain separation between
+   pre-shared keys used by the core MLS protocol and applications, and
+   between those used by different components.
+
+   enum {
+     // ...
+     application(3),
+     (255)
+   } PSKType;
+
+   struct {
+     PSKType psktype;
+     select (PreSharedKeyID.psktype) {
+       // ...
+       case application:
+         ComponentID component_id;
+         opaque psk_id<V>;
+     };
+     opaque psk_nonce<V>;
+   } PreSharedKeyID;
+
+4.6.  Attaching Application Data to MLS Messages
+
+   The MLS GroupContext, LeafNode, KeyPackage, and GroupInfo objects
+   each have an extensions field that can carry additional data not
+   defined by the MLS specification.  The app_data_dictionary extension
+   provides a generic container that applications can use to attach
+   application data to these messages.  Each usage of the extension
+   serves a slightly different purpose:
+
+   *  GroupContext: Confirms that all members of the group agree on the
+      application data, and automatically distributes it to new joiners.
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 10]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   *  KeyPackage and LeafNode: Associates the application data to a
+      particular client, and advertises it to the other members of the
+      group.
+
+   *  GroupInfo: Distributes the application data confidentially to the
+      new joiners for whom the GroupInfo is encrypted (as a Welcome
+      message).
+
+   The content of the app_data_dictionary extension is a serialized
+   AppDataDictionary object:
+
+   struct {
+       ComponentID component_id;
+       opaque data<V>;
+   } ComponentData;
+
+   struct {
+       ComponentData component_data<V>;
+   } AppDataDictionary;
+
+   The entries in the component_data MUST be sorted by component_id, and
+   there MUST be at most one entry for each component_id.
+
+   An app_data_dictionary extension in a LeafNode, KeyPackage, or
+   GroupInfo can be set when the object is created.  An
+   app_data_dictionary extension in the GroupContext needs to be managed
+   using the tools available to update GroupContext extensions.  The
+   creator of the group can set extensions unilaterally.  Thereafter,
+   the AppDataUpdate proposal described in the next section is used to
+   update the app_data_dictionary extension.
+
+4.7.  Updating Application Data in the GroupContext
+
+   Updating the app_data_dictionary with a GroupContextExtensions
+   proposal is cumbersome.  The application data needs to be transmitted
+   in its entirety, along with any other extensions, whether or not they
+   are being changed.  And a GroupContextExtensions proposal always
+   requires an UpdatePath, which updating application state never
+   should.
+
+   The AppDataUpdate proposal allows the app_data_dictionary extension
+   to be updated without these costs.  Instead of sending the whole
+   value of the extension, it sends only an update, which is interpreted
+   by the application to provide the new content for the
+   app_data_dictionary extension.  No other extensions are sent or
+   updated, and no UpdatePath is required.
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 11]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   enum {
+       invalid(0),
+       update(1),
+       remove(2),
+       (255)
+   } AppDataUpdateOperation;
+
+   struct {
+       ComponentID component_id;
+       AppDataUpdateOperation op;
+
+       select (AppDataUpdate.op) {
+           case update: opaque update<V>;
+           case remove: struct{};
+       };
+   } AppDataUpdate;
+
+   An AppDataUpdate proposal is invalid if its component_id references a
+   component that is not known to the application, or if it specifies
+   the removal of state for a component_id that has no state present.  A
+   proposal list is invalid if it includes multiple AppDataUpdate
+   proposals that remove state for the same component_id, or proposals
+   that both update and remove state for the same component_id.  In
+   other words, for a given component_id, a proposal list is valid only
+   if it contains (a) a single remove operation or (b) one or more
+   update operation.
+
+   AppDataUpdate proposals are processed after any default proposals
+   (i.e., those defined in [RFC9420]), and any AppEphemeral proposals
+   (defined in Section 4.8).
+
+   When an MLS group contains the AppDataUpdate proposal type in the
+   proposal_types list in the group's required_capabilities extension, a
+   GroupContextExtensions proposal MUST NOT add, remove, or modify the
+   app_data_dictionary GroupContext extension.  In other words, when
+   every member of the group supports the AppDataUpdate proposal, a
+   GroupContextExtensions proposal could be sent to update some other
+   extension(s), but the app_data_dictionary GroupContext extension, if
+   it exists, is left as it was.
+
+   A commit can contain a GroupContextExtensions proposal which modifies
+   GroupContext extensions other than app_data_dictionary, and can be
+   followed by zero or more AppDataUpdate proposals.  This allows
+   modifications to both the app_data_dictionary extension (via
+   AppDataUpdate) and other extensions (via GroupContextExtensions) in
+   the same Commit.
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 12]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   A client applies AppDataUpdate proposals by component ID.  For each
+   component_id field that appears in an AppDataUpdate proposal in the
+   Commit, the client assembles a list of AppDataUpdate proposals with
+   that component_id, in the order in which they appear in the Commit,
+   and processes them in the following way:
+
+   *  If the list comprises a single proposal with the op field set to
+      remove:
+
+      -  If there is an entry in the component_states vector in the
+         application_state extension with the specified component_id,
+         remove it.
+
+      -  Otherwise, the proposal is invalid.
+
+   *  If the list comprises one or more proposals, all with op field set
+      to update:
+
+      -  Provide the application logic registered to the component_id
+         value with the content of the update field from each proposal,
+         in the order specified.
+
+      -  The application logic returns either an opaque value new_data
+         that will be stored as the new application data for this
+         component, or else an indication that it considers this update
+         invalid.
+
+      -  If the application logic considers the update invalid, the MLS
+         client MUST consider the proposal list invalid.
+
+      -  If no app_data_dictionary extension is present in the
+         GroupContext, add one to the end of the extensions list in the
+         GroupContext.
+
+      -  If there is an entry in the component_data vector in the
+         app_data_dictionary extension with the specified component_id,
+         then set its data field to the specified new_data.
+
+      -  Otherwise, insert a new entry in the component_states vector
+         with the specified component_id and the data field set to the
+         new_data value.  The new entry is inserted at the proper point
+         to keep the component_states vector sorted by component_id.
+
+   *  Otherwise, the proposal list is invalid.
+
+      NOTE: An alternative design here would be to have the update
+      operation simply set the new value for the app_data_dictionary
+      GCE, instead of sending a diff.  This would be simpler in that the
+
+
+
+Robert                   Expires 22 January 2026               [Page 13]
+
+Internet-Draft                     MLS                         July 2025
+
+
+      MLS stack wouldn't have to ask the application for the new state
+      value, and would discourage applications from storing large state
+      in the GroupContext directly (which bloats Welcome messages).  It
+      would effectively require the state in the GroupContext to be a
+      hash of the real state, to avoid large AppDataUpdate proposals.
+      This pushes some complexity onto the application, since the
+      application has to define a hashing algorithm, and define its own
+      scheme for initializing new joiners.
+
+   AppDataUpdate proposals do not require an UpdatePath.  An
+   AppDataUpdate proposal can be sent by an external sender.  Likewise,
+   AppDataUpdate proposals can be included in an external commit.
+   Applications can make more restrictive validity rules for the update
+   of their components, such that some components would not be valid at
+   the application when sent in an external commit or via an external
+   proposer.
+
+4.8.  Attaching Application Data to a Commit
+
+   The AppEphemeral proposal type allows an application component to
+   associate application data to a Commit, so that the member processing
+   the Commit knows that all other group members will be processing the
+   same data.  AppEphemeral proposals are ephemeral in the sense that
+   they do not change any persistent state related to MLS, aside from
+   their appearance in the transcript hash.
+
+   The content of an AppEphemeral proposal is the same as an
+   app_data_dictionary extension.  The proposal type is set in
+   Section 7.
+
+   struct {
+       ComponentID component_id;
+       opaque data<V>;
+   } AppEphemeral;
+
+   An AppEphemeral proposal is invalid if it contains a component_id
+   that is unknown to the application, or if the app_data_dictionary
+   field contains any ComponentData entry whose data field is considered
+   invalid by the application logic registered to the indicated
+   component_id.
+
+   AppEphemeral proposals MUST be processed after any default proposals
+   (i.e., those defined in [RFC9420]), but before any AppDataUpdate
+   proposals.
+
+
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 14]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   A client applies an AppEphemeral proposal by providing the contents
+   of the app_data_dictionary field to the component identified by the
+   component_id.  If a Commit references more than one AppEphemeral
+   proposal for the same component_id value, then they MUST be processed
+   in the order in which they are specified in the Commit.
+
+   AppEphemeral proposals do not require an UpdatePath.  An AppEphemeral
+   proposal can be sent by an external sender.  Likewise, AppEphemeral
+   proposals can be included in an external commit.  Applications can
+   make more restrictive validity rules for ephemeral updates of their
+   components, such that some components would not be valid at the
+   application when sent in an external commit or via an external
+   proposer.
+
+4.9.  Safe Additional Authenticated Data (AAD)
+
+   Both MLS PublicMessage and PrivateMessage messages can contain
+   arbitrary additional application-specific data.  The corresponding
+   authenticated_data field that conveys this application-specific data
+   appears in the FramedContent struct for PublicMessage and directly in
+   the PrivateMessage struct.
+
+   In an MLS PrivateMessage, the application_data is also present in
+   intermediary structs: in the FramedContent, which is used to generate
+   the message signature and tags, and in the PrivateContentAAD, which
+   is used as the AAD input to the PrivateMessage.ciphertext.
+
+   The Safe AAD API defines a framing used to allow multiple application
+   components to add AAD safely to the authenticated_data without
+   conflicts or ambiguity.
+
+   When any AAD safe extension is included in the authenticated_data
+   field, the "safe" AAD items MUST come before any non-safe data in the
+   authenticated_data field.  Safe AAD items are framed using the
+   SafeAAD struct and are sorted in increasing numerical order of the
+   component_id.  The struct is described below:
+
+   struct {
+     ComponentID component_id;
+     opaque aad_item_data<V>;
+   } SafeAADItem;
+
+   struct {
+     SafeAADItem aad_items<V>;
+   } SafeAAD;
+
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 15]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   If the SafeAAD is present or not in the authenticated_data is
+   determined by the presence of the safe_aad component in the
+   app_data_dictionary extension in the GroupContext (see Section 5).
+   If safe_aad is present, but none of the "safe" AAD components have
+   data to send in a particular message, the aad_items is a zero-length
+   vector.
+
+5.  Negotiating Extensions and Components
+
+   MLS defines a Capabilities struct for LeafNodes (in turn used in
+   KeyPackages), which describes which extensions are supported by the
+   associated node.
+
+   However, that struct (defined in Section 7.2 of [RFC9420]) only has
+   fields for a subset of the extensions possible in MLS, as reproduced
+   below.
+
+   struct {
+       ProtocolVersion versions<V>;
+       CipherSuite cipher_suites<V>;
+       ExtensionType extensions<V>;
+       ProposalType proposals<V>;
+       CredentialType credentials<V>;
+   } Capabilities;
+
+      The "MLS Extensions Types" registry represents extensibility of
+      four core structs (GroupContext, GroupInfo, KeyPackage, and
+      LeafNode) that have far reaching effects on the use of the
+      protocol.  The majority of MLS extensions in [RFC9420] extend one
+      or more of these core structs.
+
+   Likewise, the required_capabilities GroupContext extension (defined
+   in Section 11.1 of [RFC9420] and reproduced below) contains all
+   mandatory to support non-default extensions in its extension_types
+   vector.  Its proposal_types vector contains any mandatory to support
+   Proposals.  Its credential_types vector contains any mandatory
+   credential types.
+
+   struct {
+      ExtensionType extension_types<V>;
+      ProposalType proposal_types<V>;
+      CredentialType credential_types<V>;
+   } RequiredCapabilities;
+
+   Due to an oversight in [RFC9420], the Capabilities struct does not
+   include MLS Wire Formats.  Instead, this document defines two
+   extensions: supported_wire_formats (which can appear in LeafNodes),
+   and required_wire_formats (which can appear in the GroupContext).
+
+
+
+Robert                   Expires 22 January 2026               [Page 16]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   struct {
+      WireFormat wire_formats<V>;
+   } WireFormats
+
+   WireFormats supported_wire_formats;
+   WireFormats requires_wire_formats;
+
+   This document also defines new components of the app_data_dictionary
+   extension for supported and required Safe AAD, media types, and
+   components.
+
+   The safe_aad component contains a list of components IDs.  When
+   present (in an app_data_dictionary extension) in a LeafNode, the
+   semantic is the list of supported components that use Safe AAD.  When
+   present (in an app_data_dictionary extension) in the GroupContext,
+   the semantic is the list of required Safe AAD components (those that
+   must be understood by the entire group).  If the safe_aad component
+   is present, even with an empty list, (in the app_data_dictionary
+   extension) in the GroupContext, then the authenticated_data field
+   always starts with the SafeAAD struct defined in Section 4.9.
+
+   struct {
+       ComponentID component_ids<V>;
+   } ComponentsList;
+
+   ComponentsList safe_aad;
+
+   The list of required and supported components follows the same model
+   with the new component app_components.  When present in a LeafNode,
+   the semantic is the list of supported components.  When present in
+   the GroupContext, the semantic is the list of required components.
+
+   ComponentsList app_components;
+
+   Finally, the supported and required media types (formerly called MIME
+   types) are communicated in the content_media_types component (see
+   Section 6.2).
+
+5.1.  GREASE
+
+   The "Generate Random Extensions And Sustain Extensibility" (GREASE)
+   approach is described in Section 13.5 of [RFC9420].  Further,
+   Section 7.2 of [RFC9420] says that:
+
+      "As discussed in Section 13, unknown values in capabilities MUST
+      be ignored, and the creator of a capabilities field SHOULD include
+      some random GREASE values to help ensure that other clients
+      correctly ignore unknown values."
+
+
+
+Robert                   Expires 22 January 2026               [Page 17]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   This specification adds the following locations where GREASE values
+   for components can be included:
+
+   *  LeafNode.capabilities.app_data_dictionary.safe_aad
+
+   *  LeafNode.capabilities.app_data_dictionary.app_components
+
+   *  LeafNode.extensions.app_data_dictionary
+
+   *  KeyPackage.extensions.app_data_dictionary
+
+   *  GroupInfo.extensions.app_data_dictionary
+
+   *  app_ephemeral.app_data_dictionary
+
+   *  authenticated_data.aad_items
+
+   Unknown values (including GREASE values) in any of these fields MUST
+   be ignored by receivers.  A random selection of GREASE values SHOULD
+   be included in any of these fields that would otherwise be present.
+
+6.  Extensions
+
+6.1.  AppAck
+
+   An AppAck object is used to acknowledge receipt of application
+   messages.  Though this information implies no change to the group, it
+   is conveyed inside an AppEphermeral Proposal with a component ID
+   app_ack, so that it is included in the group's transcript by being
+   included in Commit messages.
+
+   struct {
+       uint32 sender;
+       uint32 first_generation;
+       uint32 last_generation;
+   } MessageRange;
+
+   struct {
+       MessageRange received_ranges<V>;
+   } AppAck;
+
+   An AppAck represents a set of messages received by the sender in the
+   current epoch.  Messages are represented by the sender and generation
+   values in the MLSCiphertext for the message.  Each MessageRange
+   represents receipt of a span of messages whose generation values form
+   a continuous range from first_generation to last_generation,
+   inclusive.
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 18]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   AppAck objects are sent as a guard against the Delivery Service
+   dropping application messages.  The sequential nature of the
+   generation field provides a degree of loss detection, since gaps in
+   the generation sequence indicate dropped messages.  AppAck completes
+   this story by addressing the scenario where the Delivery Service
+   drops all messages after a certain point, so that a later generation
+   is never observed.  Obviously, there is a risk that AppAck messages
+   could be suppressed as well, but their inclusion in the transcript
+   means that if they are suppressed then the group cannot advance at
+   all.
+
+6.2.  Content Advertisement
+
+6.2.1.  Description
+
+   This section defines a minimal framing format so MLS clients can
+   signal which media type is being sent inside the MLS application_data
+   object when multiple formats are permitted in the same group.
+
+   It also defines a new content_media_types application component which
+   is used to indicate support for specific formats, using the extensive
+   IANA Media Types registry (formerly called MIME Types).  When the
+   content_media_types component is present (in the app_data_dictionary
+   extension) in a LeafNode, it indicates that node's support for a
+   particular (non-empty) list of media types.  When the
+   content_media_types component is present (in the app_data_dictionary
+   extension) in the GroupContext, it indicates a (non-empty) list of
+   media types that need to be supported by all members of that MLS
+   group, _and_ that the application_data will be framed using the
+   application framing format described later in Section 6.2.4.  This
+   allows clients to confirm that all members of a group can
+   communicate.
+
+      Note that when the membership of a group changes, or when the
+      policy of the group changes, it is responsibility of the committer
+      to ensure that the membership and policies are compatible.
+
+   As clients are upgraded to support new formats they can use these
+   extensions to detect when all members support a new or more efficient
+   encoding, or select the relevant format or formats to send.
+
+   Vendor-specific media subtypes starting with vnd. can be registered
+   with IANA without standards action as described in [RFC6838].
+   Implementations which wish to send multiple formats in a single
+   application message, may be interested in the multipart/alternative
+   media type defined in [RFC2046] or may use or define another type
+   with similar semantics (for example using TLS Presentation Language
+   syntax [RFC8446]).
+
+
+
+Robert                   Expires 22 January 2026               [Page 19]
+
+Internet-Draft                     MLS                         July 2025
+
+
+      Note that the usage of IANA media types in general does not imply
+      the usage of MIME Headers [RFC2045] for framing.
+
+6.2.2.  Syntax
+
+   MediaType is a TLS encoding of a single IANA media type (including
+   top-level type and subtype) and any of its parameters.  Even if the
+   parameter_value would have required formatting as a quoted-string in
+   a text encoding, only the contents inside the quoted-string are
+   included in parameter_value.  Likewise, only the second character of
+   a quoted-pair is included in parameter_value; the first escaping
+   backslash ("") is omitted.  MediaTypeList is an ordered list of
+   MediaType objects.
+
+   struct {
+       opaque parameter_name<V>;
+       /* Note: parameter_value never includes the quotation marks of */
+       /* an RFC 2045 quoted-string or the first "\" of a quoted-pair */
+       opaque parameter_value<V>;
+   } Parameter;
+
+   struct {
+       /* media_type is an IANA top-level media type, a "/" character,
+        * and the IANA media subtype */
+       opaque media_type<V>;
+
+       /* a list of zero or more parameters defined for the subtype */
+       Parameter parameters<V>;
+   } MediaType;
+
+   struct {
+       /* must contain at least one item */
+       MediaType media_types<V>;
+   } MediaTypeList;
+
+   MediaTypeList content_media_types;
+
+   Example IANA media types with optional parameters:
+
+     image/png
+     text/plain ;charset="UTF-8"
+     application/json
+     application/vnd.example.msgbus+cbor
+
+   For the example media type for text/plain, the media_type field would
+   be text/plain, parameters would contain a single Parameter with a
+   parameter_name of charset and a parameter_value of UTF-8.
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 20]
+
+Internet-Draft                     MLS                         July 2025
+
+
+6.2.3.  Expected Behavior
+
+   An MLS client which implements this section SHOULD include the
+   content_media_types component (in the app_data_dictionary extension)
+   in its LeafNodes, listing all the media types it can receive.  As
+   usual, the client also includes content_media_types in the
+   app_components list (in the app_data_dictionary extension) and
+   support for the app_data_dictionary extension in its
+   capabilities.extensions field in its LeafNodes (including in
+   LeafNodes inside its KeyPackages).
+
+   When creating a new MLS group for an application using this
+   specification, the group MAY include a content_media_types component
+   (in the app_data_dictionary extension) in the GroupContext.  (The
+   creating client also includes its content_media_types component in
+   its own LeafNode as described in the previous paragraph.)
+
+   MLS clients SHOULD NOT add an MLS client to an MLS group with
+   content_media_types in its GroupContext unless the MLS client
+   advertises it can support all the required MediaTypes.  As an
+   exception, a client could be preconfigured to know that certain
+   clients support the required types.  Likewise, an MLS client is
+   already forbidden from issuing or committing a GroupContextExtensions
+   Proposal which introduces required extensions which are not supported
+   by all members in the resulting epoch.
+
+6.2.4.  Framing of application_data
+
+   When an MLS group contains the content_media_types component (in the
+   app_data_dictionary extension) in its GroupContext, the
+   application_data sent in that group is interpreted as
+   ApplicationFraming as defined below:
+
+     struct {
+         MediaType media_type;
+         opaque<V> application_content;
+     } ApplicationFraming;
+
+   The media_type MAY be zero length, in which case, the media type of
+   the application_content is interpreted as the first MediaType
+   specified in the content_media_types component in the GroupContext.
+
+
+
+
+
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 21]
+
+Internet-Draft                     MLS                         July 2025
+
+
+6.3.  SelfRemove Proposal
+
+   The design of the MLS protocol prevents a member of an MLS group from
+   removing itself immediately from the group.  (To cause an immediate
+   change in the group, a member must send a Commit message.  However,
+   the sender of a Commit message knows the keying material of the new
+   epoch and therefore needs to be part of the group.)  Instead, a
+   member wishing to remove itself can send a Remove Proposal and wait
+   for another member to Commit its Proposal.
+
+   Unfortunately, MLS clients that join via an External Commit ignore
+   pending, but otherwise valid, Remove Proposals.  The member trying to
+   remove itself has to monitor the group and send a new Remove Proposal
+   in every new epoch until the member is removed.  In a group with a
+   burst of external joiners, a member connected over a high-latency
+   link (or one that is merely unlucky) might have to wait several
+   epochs to remove itself.  A real-world situation in which this
+   happens is a member trying to remove itself from a conference call as
+   several dozen new participants are trying to join (often on the
+   hour).
+
+   This section describes a new SelfRemove proposal type.  It is
+   designed to be included in External Commits.
+
+6.3.1.  Proposal Description
+
+   This document specifies a new MLS Proposal type called SelfRemove.
+   Its syntax is described using the TLS Presentation Language [RFC8446]
+   below (its content is an empty struct).  It is allowed in External
+   Commits and requires an UpdatePath.  SelfRemove proposals are only
+   allowed in a Commit by reference.  SelfRemove cannot be sent as an
+   external proposal.
+
+   struct {} SelfRemove;
+
+   struct {
+       ProposalType msg_type;
+       select (Proposal.msg_type) {
+           case add:                      Add;
+           case update:                   Update;
+           case remove:                   Remove;
+           case psk:                      PreSharedKey;
+           case reinit:                   ReInit;
+           case external_init:            ExternalInit;
+           case group_context_extensions: GroupContextExtensions;
+           case self_remove:              SelfRemove;
+       };
+   } Proposal;
+
+
+
+Robert                   Expires 22 January 2026               [Page 22]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   The description of behavior below only applies if all the members of
+   a group support this proposal in their capabilities; such a group is
+   a "self-remove-capable group".
+
+   An MLS client which supports this proposal can send a SelfRemove
+   Proposal whenever it would like to remove itself from a self-remove-
+   capable group.  Because the point of a SelfRemove Proposal is to be
+   available to external joiners (which are not yet members), these
+   proposals MUST be sent in an MLS PublicMessage.
+
+   Whenever a member receives a SelfRemove Proposal, it includes it
+   along with any other pending Propsals when sending a Commit.  It
+   already MUST send a Commit of pending Proposals before sending new
+   application messages.
+
+   When a member receives a Commit referencing one or more SelfRemove
+   Proposals, it treats the proposal like a Remove Proposal, except the
+   leaf node to remove is determined by looking in the Sender leaf_index
+   of the original Proposal.  The member is able to verify that the
+   Sender was a member.
+
+   Whenever a new joiner is about to join a self-remove-capable group
+   with an External Commit, the new joiner MUST fetch any pending
+   SelfRemove Proposals along with the GroupInfo object, and include the
+   SelfRemove Proposals in its External Commit by reference.  (An
+   ExternalCommit can contain zero or more SelfRemove proposals).  The
+   new joiner MUST validate the SelfRemove Proposal before including it
+   by reference, except that it skips the validation of the
+   membership_tag because a non-member cannot verify membership.
+
+   During validation, SelfRemove proposals are processed after Update
+   proposals and before Remove proposals.  If there is a pending
+   SelfRemove proposal for a specific leaf node and a pending Remove
+   proposal for the same leaf node, the Remove proposal is invalid.  A
+   client MUST NOT issue more than one SelfRemove proposal per epoch.
+
+   The MLS Delivery Service (DS) needs to validate SelfRemove Proposals
+   it receives (except that it cannot validate the membership_tag).  If
+   the DS provides a GroupInfo object to an external joiner, the DS
+   SHOULD attach any SelfRemove proposals known to the DS to the
+   GroupInfo object.
+
+   As with Remove proposals, clients need to be able to receive a Commit
+   message which removes them from the group via a SelfRemove.  If the
+   DS does not forward a Commit to a removed client, it needs to inform
+   the removed client out-of-band.
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 23]
+
+Internet-Draft                     MLS                         July 2025
+
+
+6.4.  Last resort KeyPackages
+
+   Type: KeyPackage extension
+
+6.4.1.  Description
+
+   Section 10 of [RFC9420] details that clients are required to pre-
+   publish KeyPackages so that other clients can add them to groups
+   asynchronously.  It also states that they should not be re-used:
+
+      KeyPackages are intended to be used only once and SHOULD NOT be
+      reused except in the case of a "last resort" KeyPackage (see
+      Section 16.8).  Clients MAY generate and publish multiple
+      KeyPackages to support multiple cipher suites.
+
+   Section 16.8 of [RFC9420] then introduces the notion of last-resort
+   KeyPackages as follows:
+
+      An application MAY allow for reuse of a "last resort" KeyPackage
+      in order to prevent denial-of-service attacks.
+
+   However, [RFC9420] does not specify how to distinguish regular
+   KeyPackages from last-resort ones.  The last_resort_key_package
+   KeyPackage application component defined in this section fills this
+   gap and allows clients to specifically mark KeyPackages as
+   KeyPackages of last resort that MAY be used more than once in
+   scenarios where all other KeyPackages have already been used.
+
+   The component allows clients that pre-publish KeyPackages to signal
+   to the Delivery Service which KeyPackage(s) are meant to be used as
+   last resort KeyPackages.
+
+   An additional benefit of using a component rather than communicating
+   the information out-of-band is that the component is still present in
+   Add proposals.  Clients processing such Add proposals can
+   authenticate that a KeyPackage is a last-resort KeyPackage and MAY
+   make policy decisions based on that information.
+
+6.4.2.  Format
+
+   The purpose of the application component is simply to mark a given
+   KeyPackage, which means it carries no additional data.
+
+   As a result, a LastResort Extension contains the component_id with an
+   empty data field.
+
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 24]
+
+Internet-Draft                     MLS                         July 2025
+
+
+6.5.  Multi-Credentials
+
+   Multi-credentials address use cases where there might not be a single
+   credential that captures all of a client's authenticated attributes.
+   For example, an enterprise messaging client may wish to provide
+   attributes both from its messaging service, to prove that its user
+   has a given handle in that service, and from its corporate owner, to
+   prove that its user is an employee of the corporation.  Multi-
+   credentials can also be used in migration scenarios, where some
+   clients in a group might wish to rely on a newer type of credential,
+   but other clients haven't yet been upgraded.
+
+   New credential types MultiCredential and WeakMultiCredential are
+   defined as shown below.  These credential types are indicated with
+   the values multi and weak-multi (see Section 7.4).
+
+   struct {
+     CipherSuite cipher_suite;
+     Credential credential;
+     SignaturePublicKey credential_key;
+
+     /* SignWithLabel(., "CredentialBindingTBS", CredentialBindingTBS) */
+     opaque signature<V>;
+   } CredentialBinding
+
+   struct {
+     CredentialBinding bindings<V>;
+   } MultiCredential;
+
+   struct {
+     CredentialBinding bindings<V>;
+   } WeakMultiCredential;
+
+   The two types of credentials are processed in exactly the same way.
+   The only difference is in how they are treated when evaluating
+   support by other clients, as discussed below.
+
+6.5.1.  Credential Bindings
+
+   A multi-credential consists of a collection of "credential bindings".
+   Each credential binding is a signed statement by the holder of the
+   credential that the signature key in the LeafNode belongs to the
+   holder of that credential.  Specifically, the signature is computed
+   using the MLS SignWithLabel function, with label
+   "CredentialBindingTBS" and with a content that covers the contents of
+   the CredentialBinding, plus the signature_key field from the LeafNode
+   in which this credential will be embedded.
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 25]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   struct {
+     CipherSuite cipher_suite;
+     Credential credential;
+     SignaturePublicKey credential_key;
+     SignaturePublicKey signature_key;
+   } CredentialBindingTBS;
+
+   The cipher_suite for a credential is NOT REQUIRED to match the cipher
+   suite for the MLS group in which it is used, but MUST meet the
+   support requirements with regard to support by group members
+   discussed below.
+
+6.5.2.  Verifying a Multi-Credential
+
+   A credential binding is supported by a client if the client supports
+   the credential type and cipher suite of the binding.  A credential
+   binding is valid in the context of a given LeafNode if both of the
+   following are true:
+
+   *  The credential is valid according to the MLS Authentication
+      Service.
+
+   *  The credential_key corresponds to the specified credential, in the
+      same way that the signature_key would have to correspond to the
+      credential if the credential were presented in a LeafNode.
+
+   *  The signature field is valid with respect to the signature_key
+      value in the leaf node.
+
+   A client that receives a credential of type multi in a LeafNode MUST
+   verify that all the following are true:
+
+   *  All members of the group support credential type multi.
+
+   *  For each credential binding in the multi-credential:
+
+      -  Every member of the group supports the cipher suite and
+         credential type values for the binding.
+
+      -  The binding is valid in the context of the LeafNode.
+
+   A client that receives a credential of type weak-multi in a LeafNode
+   MUST verify that all the following are true:
+
+   *  All members of the group support credential type weak-multi.
+
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 26]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   *  Each member of the group supports at least one binding in the
+      multi-credential.  (Different members may support different
+      subsets.)
+
+   *  Every binding that this client supports is valid in the context of
+      the LeafNode.
+
+7.  IANA Considerations
+
+   This document requests the addition of various new values under the
+   heading of "Messaging Layer Security".  Each registration is
+   organized under the relevant registry Type.
+
+   This document also requests the creation of a new MLS applications
+   components registry as described in Section 7.5.
+
+   RFC EDITOR: Please replace XXXX throughout with the RFC number
+   assigned to this document
+
+7.1.  MLS Wire Formats
+
+7.2.  MLS Extension Types
+
+7.2.1.  app_data_dictionary MLS Extension
+
+   The app_data_dictionary MLS Extension Type is used inside KeyPackage,
+   LeafNode, GroupContext, or GroupInfo objects.  It contains a sorted
+   list of application component data objects (at most one per
+   component).
+
+   *  Value: 0x0006 (suggested)
+
+   *  Name: app_data_dictionary
+
+   *  Message(s): KP: This extension may appear in KeyPackage objects
+      LN: This extension may appear in LeafNode objects GC: This
+      extension may appear in GroupContext objects GI: This extension
+      may appear in GroupInfo objects
+
+   *  Recommended: Y
+
+   *  Reference: RFC XXXX
+
+7.2.2.  supported_wire_formats MLS Extension
+
+   The supported_wire_formats MLS Extension Type is used inside LeafNode
+   objects.  It contains a list of non-default Wire Formats supported by
+   the client node.
+
+
+
+Robert                   Expires 22 January 2026               [Page 27]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   *  Value: 0x0007 (suggested)
+
+   *  Name: supported_wire_formats
+
+   *  Message(s): LN: This extension may appear in LeafNode objects
+
+   *  Recommended: Y
+
+   *  Reference: RFC XXXX
+
+7.2.3.  required_wire_formats MLS Extension
+
+   The required_wire_formats MLS Extension Type is used inside
+   GroupContext objects.  It contains a list of non-default Wire Formats
+   that are mandatory for all MLS members of the group to support.
+
+   *  Value: 0x0008 (suggested)
+
+   *  Name: required_wire_formats
+
+   *  Message(s): GC: This extension may appear in GroupContext objects
+
+   *  Recommended: Y
+
+   *  Reference: RFC XXXX
+
+7.3.  MLS Proposal Types
+
+7.3.1.  AppDataUpdate Proposal
+
+   The app_data_update MLS Proposal Type is used to efficiently update
+   application component data stored in the app_data_dictionary
+   GroupContext extension.
+
+   *  Value: 0x0008 (suggested)
+
+   *  Name: app_data_update
+
+   *  Recommended: Y
+
+   *  External: Y
+
+   *  Path Required: N
+
+
+
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 28]
+
+Internet-Draft                     MLS                         July 2025
+
+
+7.3.2.  AppEphemeral Proposal
+
+   The app_ephemeral MLS Proposal Type is used to send opaque ephemeral
+   application data that needs to be synchronized with a specific MLS
+   epoch.
+
+   *  Value: 0x0009 (suggested)
+
+   *  Name: app_ephemeral
+
+   *  Recommended: Y
+
+   *  External: Y
+
+   *  Path Required: N
+
+7.3.3.  SelfRemove Proposal
+
+   The self_remove MLS Proposal Type is used for a member to remove
+   itself from a group more efficiently than using a remove proposal
+   type, as the self_remove type is permitted in External Commits.
+
+   *  Value: 0x000a (suggested)
+
+   *  Name: self_remove
+
+   *  Recommended: Y
+
+   *  External: N
+
+   *  Path Required: Y
+
+7.3.4.  AppAck Proposal
+
+   The app_ack MLS Proposal Type can be used by group members to
+   acknowledge the receipt of application messages.
+
+   *  Value: 0x000b (suggested)
+
+   *  Name: app_ack
+
+   *  Recommended: Y
+
+   *  External: N
+
+   *  Path Required: N
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 29]
+
+Internet-Draft                     MLS                         July 2025
+
+
+7.4.  MLS Credential Types
+
+7.4.1.  Multi Credential
+
+   *  Value: 0x0003 (suggested)
+
+   *  Name: multi
+
+   *  Recommended: Y
+
+   *  Reference: RFC XXXX
+
+7.4.2.  Weak Multi Credential
+
+   *  Value: 0x0004
+
+   *  Name: weak-multi
+
+   *  Recommended: Y
+
+   *  Reference: RFC XXXX
+
+7.4.3.  CredentialBindingTBS
+
+   *  Label: "CredentialBindingTBS"
+
+   *  Recommended: Y
+
+   *  Reference: RFC XXXX
+
+7.5.  MLS Component Types
+
+   This document requests the creation of a new IANA "MLS Component
+   Types" registry under the "Messaging Layer Security" group registry
+   heading.  Assignments to this registry in the range 0x0000 0000 to
+   0x7FFF FFFF are via Specification Required policy [RFC8126] using the
+   MLS Designated Experts.  Assignments in the range 0x8000 0000 to
+   0xFFFF FFFF are for private use.
+
+   Template:
+
+   *  Value: The numeric value of the component ID
+
+   *  Name: The name of the component
+
+   *  Where: The objects(s) in which the component may appear, drawn
+      from the following list:
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 30]
+
+Internet-Draft                     MLS                         July 2025
+
+
+      -  AD: SafeAAD objects
+
+      -  AE: AppEpheral proposals
+
+      -  ES: Exporter Secret labels
+
+      -  GC: GroupContext objects
+
+      -  GI: GroupInfo objects
+
+      -  HP: HPKE key labels
+
+      -  KP: KeyPackage objects
+
+      -  LN: LeafNode objects
+
+      -  PS: PSK labels
+
+      -  SK: Signature Key labels
+
+   *  Recommended: Same as in Section 17.1 of [RFC9420]
+
+   *  Reference: The document where this component is defined
+
+   The restrictions noted in the "Where" column are to be enforced by
+   the application.  MLS implementations MUST NOT impose restrictions on
+   where component IDs are used in which parts of MLS, unless
+   specifically directed to by the application.
+
+   Initial Contents:
+
+    +===============+==========================+=======+===+=========+
+    | Value         | Name                     | Where | R | Ref     |
+    +===============+==========================+=======+===+=========+
+    | 0x0000 0000   | RESERVED                 | N/A   | - | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 0001   | app_components           | LN,GC | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 0002   | safe_aad                 | LN,GC | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 0003   | content_media_types      | LN,GC | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 0004   | last_resort_key_package  | KP    | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 0005   | app_ack                  | AE    | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 0a0a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+
+
+
+Robert                   Expires 22 January 2026               [Page 31]
+
+Internet-Draft                     MLS                         July 2025
+
+
+    | 0x0000 1a1a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 2a2a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 3a3a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 4a4a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 5a5a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 6a6a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 7a7a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 8a8a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 9a9a   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 aaaa   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 baba   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 caca   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 dada   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x0000 eaea   | GREASE                   | Note1 | Y | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+    | 0x8000 0000 - |                          |       |   |         |
+    +---------------+--------------------------+-------+---+---------+
+    | 0xFFFF FFFF   | Reserved for Private Use | N/A   | N | RFCXXXX |
+    +---------------+--------------------------+-------+---+---------+
+
+                                 Table 1
+
+      Note1: GREASE values for components MAY be present in AD, AE, GI,
+      KP, and LN objects.
+
+8.  Security considerations
+
+8.1.  Safe Application API
+
+   The Safe Application API provides the following security guarantee:
+   If an application uses MLS with application components, the security
+   guarantees of the base MLS protocol and the security guarantees of
+   each application component analyzed in isolation, still hold for the
+   composed application of the MLS protocol.  In other words, the Safe
+   Application API protects applications from careless component
+
+
+
+Robert                   Expires 22 January 2026               [Page 32]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   developers.  It is not possible that a combination of components (the
+   developers of which did not know about each other) impedes the
+   security of the base MLS protocol or any other component.  No further
+   analysis of the combination is necessary.  This also means that any
+   security vulnerabilities introduced by one component do not spread to
+   other components or the base MLS implementation.
+
+8.2.  AppAck
+
+   When AppAck objects are received, they allow clients to detect if the
+   Delivery Service (or an intermediary) dropped application messages,
+   since gaps in the generation sequence indicate dropped messages.
+   When AppAck messages are accepted by the Delivery Service, but not
+   received by some members, the members who have missed the
+   corresponding AppEphemeral proposals will not be able to send or
+   receive a commit message, because the proposal is included in the
+   transcript hash.  Likewise, if AppAck objects and/or commits are sent
+   periodically by every member, other members will be able to detect a
+   member that is no longer sending on that schedule or whose handshake
+   messages are being suppressed by the DS.
+
+      Note: External Commits do not typically contain pending proposals
+      (including AppEphemeral proposals).  Client that send an AppAck
+      component in an AppEphemeral proposal will need to send a new
+      AppAck component in an AppEphemeral proposal (in the new epoch)
+      after receiving an External Commit until it has been incorporated
+      into an accepted Commit.
+
+   The schedule on which AppAck objects are sent in AppEphemeral
+   proposals is up to the application, and determines which cases of
+   loss/suppression are detected.  For example:
+
+   *  The application might have the committer include an AppAck
+      whenever a Commit is sent, so that other members could know when
+      one of their messages did not reach the committer.
+
+   *  The application could have a client send an AppAck whenever an
+      application message is sent, covering all messages received since
+      its last AppAck.  This would provide a complete view of any losses
+      experienced by active members.
+
+   *  The application could simply have clients send AppAck proposals on
+      a timer, so that all participants' state would be known.
+
+   An application using AppAck to guard against loss/suppression of
+   application messages also needs to ensure that AppAck messages and
+   the Commits that reference them are not dropped.  One way to do this
+   is to always encrypt Proposal and Commit messages, to make it more
+
+
+
+Robert                   Expires 22 January 2026               [Page 33]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   difficult for the Delivery Service to recognize which messages
+   contain AppAcks.  The application can also have clients enforce an
+   AppAck schedule, reporting loss if an AppAck is not received at the
+   expected time.
+
+8.3.  Content Advertisement
+
+   Use of the content_media_types component could leak some private
+   information visible in KeyPackages and inside an MLS group.  This
+   could be used to infer a specific implementation, platform, or even
+   version.  Clients should carefully consider the privacy implications
+   in their environment of making a list of acceptable media types
+   available.
+
+   Implementations need to be prepared to parse media types containing
+   long parameter lists, potentially containing characters which would
+   be escaped or quoted in [RFC5322].
+
+8.4.  SelfRemove
+
+   An external recipient of a SelfRemove Proposal cannot verify the
+   membership_tag.  However, an external joiner also has no way to
+   completely validate a GroupInfo object that it receives.  An insider
+   can prevent an External Join by providing either an invalid GroupInfo
+   object or an invalid SelfRemove Proposal.  The security properties of
+   external joins does not change with the addition of this proposal
+   type.
+
+8.5.  Multi Credentials
+
+   Using a Weak Multi Credential reduces the overall credential security
+   to the security of the least secure of its credential bindings.
+
+9.  References
+
+9.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/rfc/rfc2119>.
+
+   [RFC5322]  Resnick, P., Ed., "Internet Message Format", RFC 5322,
+              DOI 10.17487/RFC5322, October 2008,
+              <https://www.rfc-editor.org/rfc/rfc5322>.
+
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 34]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   [RFC8126]  Cotton, M., Leiba, B., and T. Narten, "Guidelines for
+              Writing an IANA Considerations Section in RFCs", BCP 26,
+              RFC 8126, DOI 10.17487/RFC8126, June 2017,
+              <https://www.rfc-editor.org/rfc/rfc8126>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/rfc/rfc8174>.
+
+   [RFC8446]  Rescorla, E., "The Transport Layer Security (TLS) Protocol
+              Version 1.3", RFC 8446, DOI 10.17487/RFC8446, August 2018,
+              <https://www.rfc-editor.org/rfc/rfc8446>.
+
+   [RFC9180]  Barnes, R., Bhargavan, K., Lipp, B., and C. Wood, "Hybrid
+              Public Key Encryption", RFC 9180, DOI 10.17487/RFC9180,
+              February 2022, <https://www.rfc-editor.org/rfc/rfc9180>.
+
+   [RFC9420]  Barnes, R., Beurdouche, B., Robert, R., Millican, J.,
+              Omara, E., and K. Cohn-Gordon, "The Messaging Layer
+              Security (MLS) Protocol", RFC 9420, DOI 10.17487/RFC9420,
+              July 2023, <https://www.rfc-editor.org/rfc/rfc9420>.
+
+9.2.  Informative References
+
+   [I-D.ietf-mls-architecture]
+              Beurdouche, B., Rescorla, E., Omara, E., Inguva, S., and
+              A. Duric, "The Messaging Layer Security (MLS)
+              Architecture", Work in Progress, Internet-Draft, draft-
+              ietf-mls-architecture-15, 3 August 2024,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-mls-
+              architecture-15>.
+
+   [RFC2045]  Freed, N. and N. Borenstein, "Multipurpose Internet Mail
+              Extensions (MIME) Part One: Format of Internet Message
+              Bodies", RFC 2045, DOI 10.17487/RFC2045, November 1996,
+              <https://www.rfc-editor.org/rfc/rfc2045>.
+
+   [RFC2046]  Freed, N. and N. Borenstein, "Multipurpose Internet Mail
+              Extensions (MIME) Part Two: Media Types", RFC 2046,
+              DOI 10.17487/RFC2046, November 1996,
+              <https://www.rfc-editor.org/rfc/rfc2046>.
+
+   [RFC6838]  Freed, N., Klensin, J., and T. Hansen, "Media Type
+              Specifications and Registration Procedures", BCP 13,
+              RFC 6838, DOI 10.17487/RFC6838, January 2013,
+              <https://www.rfc-editor.org/rfc/rfc6838>.
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 35]
+
+Internet-Draft                     MLS                         July 2025
+
+
+Appendix A.  Change Log
+
+   RFC EDITOR PLEASE DELETE THIS SECTION.
+
+   draft-07 - add AppAck to IANA considerations - adapt Safe AAD scope -
+   remove targeted messages altogether with intention to publish it as a
+   separate document - assign self_remove proposal to a non duplicate
+   number (0x000a) - refactor TargetedMessage to no longer use structs
+   removed from when it was a "safe extension" - remove the no-longer
+   needed targeted_messages_capability (now signaled using
+   support_wire_formats and required_wire_formats) - add
+   TargetedMessageTBS and CredentialBundleTBS to MLS Signature Labels
+   IANA registry - add GREASE values for components - fix safe exporter
+   definition - resolve TODOs from -06 - fix numerous typos
+
+   draft-06
+
+   *  Integrate notion of Application API from draft-barnes-mls-appsync
+
+   draft-05
+
+   *  Include definition of ExtensionState extension
+
+   *  Add safe use of AAD to Safe Extensions framework
+
+   *  Clarify how capabilities negotiation works in Safe Extensions
+      framework
+
+   draft-04
+
+   *  No changes (prevent expiration)
+
+   draft-03
+
+   *  Add Last Resort KeyPackage extension
+
+   *  Add Safe Extensions framework
+
+   *  Add SelfRemove Proposal
+
+   draft-02
+
+   *  No changes (prevent expiration)
+
+   draft-01
+
+   *  Add Content Advertisement extensions
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 36]
+
+Internet-Draft                     MLS                         July 2025
+
+
+   draft-00
+
+   *  Initial adoption of draft-robert-mls-protocol-00 as a WG item.
+
+   *  Add Targeted Messages extension (*)
+
+Contributors
+
+   Joel Alwen
+   Amazon
+   Email: alwenjo@amazon.com
+
+
+   Konrad Kohbrok
+   Phoenix R&D
+   Email: konrad.kohbrok@datashrine.de
+
+
+   Rohan Mahy
+   Rohan Mahy Consulting Services
+   Email: rohan.ietf@gmail.com
+
+
+   Marta Mularczyk
+   Amazon
+   Email: mulmarta@amazon.com
+
+
+   Richard Barnes
+   Cisco Systems
+   Email: rlb@ipv.sx
+
+
+Author's Address
+
+   Raphael Robert
+   Phoenix R&D
+   Email: ietf@raphaelrobert.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+Robert                   Expires 22 January 2026               [Page 37]

--- a/docs/mls/rfc9420.txt
+++ b/docs/mls/rfc9420.txt
@@ -1,0 +1,7040 @@
+﻿
+
+
+
+Internet Engineering Task Force (IETF)                         R. Barnes
+Request for Comments: 9420                                         Cisco
+Category: Standards Track                                  B. Beurdouche
+ISSN: 2070-1721                                          Inria & Mozilla
+                                                               R. Robert
+                                                             Phoenix R&D
+                                                             J. Millican
+                                                          Meta Platforms
+                                                                E. Omara
+                                                                        
+                                                          K. Cohn-Gordon
+                                                    University of Oxford
+                                                               July 2023
+
+
+              The Messaging Layer Security (MLS) Protocol
+
+Abstract
+
+   Messaging applications are increasingly making use of end-to-end
+   security mechanisms to ensure that messages are only accessible to
+   the communicating endpoints, and not to any servers involved in
+   delivering messages.  Establishing keys to provide such protections
+   is challenging for group chat settings, in which more than two
+   clients need to agree on a key but may not be online at the same
+   time.  In this document, we specify a key establishment protocol that
+   provides efficient asynchronous group key establishment with forward
+   secrecy (FS) and post-compromise security (PCS) for groups in size
+   ranging from two to thousands.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 7841.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   https://www.rfc-editor.org/info/rfc9420.
+
+Copyright Notice
+
+   Copyright (c) 2023 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Revised BSD License text as described in Section 4.e of the
+   Trust Legal Provisions and are provided without warranty as described
+   in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction
+   2.  Terminology
+     2.1.  Presentation Language
+       2.1.1.  Optional Value
+       2.1.2.  Variable-Size Vector Length Headers
+   3.  Protocol Overview
+     3.1.  Cryptographic State and Evolution
+     3.2.  Example Protocol Execution
+     3.3.  External Joins
+     3.4.  Relationships between Epochs
+   4.  Ratchet Tree Concepts
+     4.1.  Ratchet Tree Terminology
+       4.1.1.  Ratchet Tree Nodes
+       4.1.2.  Paths through a Ratchet Tree
+     4.2.  Views of a Ratchet Tree
+   5.  Cryptographic Objects
+     5.1.  Cipher Suites
+       5.1.1.  Public Keys
+       5.1.2.  Signing
+       5.1.3.  Public Key Encryption
+     5.2.  Hash-Based Identifiers
+     5.3.  Credentials
+       5.3.1.  Credential Validation
+       5.3.2.  Credential Expiry and Revocation
+       5.3.3.  Uniquely Identifying Clients
+   6.  Message Framing
+     6.1.  Content Authentication
+     6.2.  Encoding and Decoding a Public Message
+     6.3.  Encoding and Decoding a Private Message
+       6.3.1.  Content Encryption
+       6.3.2.  Sender Data Encryption
+   7.  Ratchet Tree Operations
+     7.1.  Parent Node Contents
+     7.2.  Leaf Node Contents
+     7.3.  Leaf Node Validation
+     7.4.  Ratchet Tree Evolution
+     7.5.  Synchronizing Views of the Tree
+     7.6.  Update Paths
+     7.7.  Adding and Removing Leaves
+     7.8.  Tree Hashes
+     7.9.  Parent Hashes
+       7.9.1.  Using Parent Hashes
+       7.9.2.  Verifying Parent Hashes
+   8.  Key Schedule
+     8.1.  Group Context
+     8.2.  Transcript Hashes
+     8.3.  External Initialization
+     8.4.  Pre-Shared Keys
+     8.5.  Exporters
+     8.6.  Resumption PSK
+     8.7.  Epoch Authenticators
+   9.  Secret Tree
+     9.1.  Encryption Keys
+     9.2.  Deletion Schedule
+   10. Key Packages
+     10.1.  KeyPackage Validation
+   11. Group Creation
+     11.1.  Required Capabilities
+     11.2.  Reinitialization
+     11.3.  Subgroup Branching
+   12. Group Evolution
+     12.1.  Proposals
+       12.1.1.  Add
+       12.1.2.  Update
+       12.1.3.  Remove
+       12.1.4.  PreSharedKey
+       12.1.5.  ReInit
+       12.1.6.  ExternalInit
+       12.1.7.  GroupContextExtensions
+       12.1.8.  External Proposals
+     12.2.  Proposal List Validation
+     12.3.  Applying a Proposal List
+     12.4.  Commit
+       12.4.1.  Creating a Commit
+       12.4.2.  Processing a Commit
+       12.4.3.  Adding Members to the Group
+   13. Extensibility
+     13.1.  Additional Cipher Suites
+     13.2.  Proposals
+     13.3.  Credential Extensibility
+     13.4.  Extensions
+     13.5.  GREASE
+   14. Sequencing of State Changes
+   15. Application Messages
+     15.1.  Padding
+     15.2.  Restrictions
+     15.3.  Delayed and Reordered Application Messages
+   16. Security Considerations
+     16.1.  Transport Security
+     16.2.  Confidentiality of Group Secrets
+     16.3.  Confidentiality of Sender Data
+     16.4.  Confidentiality of Group Metadata
+       16.4.1.  GroupID, Epoch, and Message Frequency
+       16.4.2.  Group Extensions
+       16.4.3.  Group Membership
+     16.5.  Authentication
+     16.6.  Forward Secrecy and Post-Compromise Security
+     16.7.  Uniqueness of Ratchet Tree Key Pairs
+     16.8.  KeyPackage Reuse
+     16.9.  Delivery Service Compromise
+     16.10. Authentication Service Compromise
+     16.11. Additional Policy Enforcement
+     16.12. Group Fragmentation by Malicious Insiders
+   17. IANA Considerations
+     17.1.  MLS Cipher Suites
+     17.2.  MLS Wire Formats
+     17.3.  MLS Extension Types
+     17.4.  MLS Proposal Types
+     17.5.  MLS Credential Types
+     17.6.  MLS Signature Labels
+     17.7.  MLS Public Key Encryption Labels
+     17.8.  MLS Exporter Labels
+     17.9.  MLS Designated Expert Pool
+     17.10. The "message/mls" Media Type
+   18. References
+     18.1.  Normative References
+     18.2.  Informative References
+   Appendix A.  Protocol Origins of Example Trees
+   Appendix B.  Evolution of Parent Hashes
+   Appendix C.  Array-Based Trees
+   Appendix D.  Link-Based Trees
+   Contributors
+   Authors' Addresses
+
+1.  Introduction
+
+   A group of users who want to send each other encrypted messages needs
+   a way to derive shared symmetric encryption keys.  For two parties,
+   this problem has been studied thoroughly, with the Double Ratchet
+   emerging as a common solution [DoubleRatchet] [Signal].  Channels
+   implementing the Double Ratchet enjoy fine-grained forward secrecy as
+   well as post-compromise security, but are nonetheless efficient
+   enough for heavy use over low-bandwidth networks.
+
+   For a group of size greater than two, a common strategy is to
+   distribute symmetric "sender keys" over existing 1:1 secure channels,
+   and then for each member to send messages to the group encrypted with
+   their own sender key.  On the one hand, using sender keys improves
+   efficiency relative to pairwise transmission of individual messages,
+   and it provides forward secrecy (with the addition of a hash
+   ratchet).  On the other hand, it is difficult to achieve post-
+   compromise security with sender keys, requiring a number of key
+   update messages that scales as the square of the group size.  An
+   adversary who learns a sender key can often indefinitely and
+   passively eavesdrop on that member's messages.  Generating and
+   distributing a new sender key provides a form of post-compromise
+   security with regard to that sender.  However, it requires
+   computation and communications resources that scale linearly with the
+   size of the group.
+
+   In this document, we describe a protocol based on tree structures
+   that enables asynchronous group keying with forward secrecy and post-
+   compromise security.  Based on earlier work on "asynchronous
+   ratcheting trees" [ART], the protocol presented here uses an
+   asynchronous key-encapsulation mechanism for tree structures.  This
+   mechanism allows the members of the group to derive and update shared
+   keys with costs that scale as the log of the group size.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+   Client:  An agent that uses this protocol to establish shared
+      cryptographic state with other clients.  A client is defined by
+      the cryptographic keys it holds.
+
+   Group:  A group represents a logical collection of clients that share
+      a common secret value at any given time.  Its state is represented
+      as a linear sequence of epochs in which each epoch depends on its
+      predecessor.
+
+   Epoch:  A state of a group in which a specific set of authenticated
+      clients hold shared cryptographic state.
+
+   Member:  A client that is included in the shared state of a group and
+      hence has access to the group's secrets.
+
+   Key Package:  A signed object describing a client's identity and
+      capabilities, including a hybrid public key encryption (HPKE)
+      [RFC9180] public key that can be used to encrypt to that client.
+      Other clients can use a client's KeyPackage to introduce the
+      client to a new group.
+
+   Group Context:  An object that summarizes the shared, public state of
+      the group.  The group context is typically distributed in a signed
+      GroupInfo message, which is provided to new members to help them
+      join a group.
+
+   Signature Key:  A signing key pair used to authenticate the sender of
+      a message.
+
+   Proposal:  A message that proposes a change to the group, e.g.,
+      adding or removing a member.
+
+   Commit:  A message that implements the changes to the group proposed
+      in a set of Proposals.
+
+   PublicMessage:  An MLS protocol message that is signed by its sender
+      and authenticated as coming from a member of the group in a
+      particular epoch, but not encrypted.
+
+   PrivateMessage:  An MLS protocol message that is signed by its
+      sender, authenticated as coming from a member of the group in a
+      particular epoch, and encrypted so that it is confidential to the
+      members of the group in that epoch.
+
+   Handshake Message:  A PublicMessage or PrivateMessage carrying an MLS
+      Proposal or Commit object, as opposed to application data.
+
+   Application Message:  A PrivateMessage carrying application data.
+
+   Terminology specific to tree computations is described in
+   Section 4.1.
+
+   In general, symmetric values are referred to as "keys" or "secrets"
+   interchangeably.  Either term denotes a value that MUST be kept
+   confidential to a client.  When labeling individual values, we
+   typically use "secret" to refer to a value that is used to derive
+   further secret values and "key" to refer to a value that is used with
+   an algorithm such as Hashed Message Authentication Code (HMAC) or an
+   Authenticated Encryption with Associated Data (AEAD) algorithm.
+
+   The PublicMessage and PrivateMessage formats are defined in
+   Section 6.  Security notions such as forward secrecy and post-
+   compromise security are defined in Section 16.
+
+   As detailed in Section 13.5, MLS uses the "Generate Random Extensions
+   And Sustain Extensibility" (GREASE) approach to maintaining
+   extensibility, where senders insert random values into fields in
+   which receivers are required to ignore unknown values.  Specific
+   "GREASE values" for this purpose are registered in the appropriate
+   IANA registries.
+
+2.1.  Presentation Language
+
+   We use the TLS presentation language [RFC8446] to describe the
+   structure of protocol messages.  In addition to the base syntax, we
+   add two additional features: the ability for fields to be optional
+   and the ability for vectors to have variable-size length headers.
+
+2.1.1.  Optional Value
+
+   An optional value is encoded with a presence-signaling octet,
+   followed by the value itself if present.  When decoding, a presence
+   octet with a value other than 0 or 1 MUST be rejected as malformed.
+
+   struct {
+       uint8 present;
+       select (present) {
+           case 0: struct{};
+           case 1: T value;
+       };
+   } optional<T>;
+
+2.1.2.  Variable-Size Vector Length Headers
+
+   In the TLS presentation language, vectors are encoded as a sequence
+   of encoded elements prefixed with a length.  The length field has a
+   fixed size set by specifying the minimum and maximum lengths of the
+   encoded sequence of elements.
+
+   In MLS, there are several vectors whose sizes vary over significant
+   ranges.  So instead of using a fixed-size length field, we use a
+   variable-size length using a variable-length integer encoding based
+   on the one described in Section 16 of [RFC9000].  They differ only in
+   that the one here requires a minimum-size encoding.  Instead of
+   presenting min and max values, the vector description simply includes
+   a V.  For example:
+
+   struct {
+       uint32 fixed<0..255>;
+       opaque variable<V>;
+   } StructWithVectors;
+
+   Such a vector can represent values with length from 0 bytes to 2^30
+   bytes.  The variable-length integer encoding reserves the two most
+   significant bits of the first byte to encode the base 2 logarithm of
+   the integer encoding length in bytes.  The integer value is encoded
+   on the remaining bits, so that the overall value is in network byte
+   order.  The encoded value MUST use the smallest number of bits
+   required to represent the value.  When decoding, values using more
+   bits than necessary MUST be treated as malformed.
+
+   This means that integers are encoded in 1, 2, or 4 bytes and can
+   encode 6-, 14-, or 30-bit values, respectively.
+
+          +========+=========+=============+=======+============+
+          | Prefix | Length  | Usable Bits | Min   | Max        |
+          +========+=========+=============+=======+============+
+          | 00     | 1       | 6           | 0     | 63         |
+          +--------+---------+-------------+-------+------------+
+          | 01     | 2       | 14          | 64    | 16383      |
+          +--------+---------+-------------+-------+------------+
+          | 10     | 4       | 30          | 16384 | 1073741823 |
+          +--------+---------+-------------+-------+------------+
+          | 11     | invalid | -           | -     | -          |
+          +--------+---------+-------------+-------+------------+
+
+                   Table 1: Summary of Integer Encodings
+
+   Vectors that start with the prefix "11" are invalid and MUST be
+   rejected.
+
+   For example:
+
+   *  The four-byte length value 0x9d7f3e7d decodes to 494878333.
+
+   *  The two-byte length value 0x7bbd decodes to 15293.
+
+   *  The single-byte length value 0x25 decodes to 37.
+
+   The following figure adapts the pseudocode provided in [RFC9000] to
+   add a check for minimum-length encoding:
+
+   ReadVarint(data):
+     // The length of variable-length integers is encoded in the
+     // first two bits of the first byte.
+     v = data.next_byte()
+     prefix = v >> 6
+     if prefix == 3:
+       raise Exception('invalid variable length integer prefix')
+
+     length = 1 << prefix
+
+     // Once the length is known, remove these bits and read any
+     // remaining bytes.
+     v = v & 0x3f
+     repeat length-1 times:
+       v = (v << 8) + data.next_byte()
+
+     // Check if the value would fit in half the provided length.
+     if prefix >= 1 && v < (1 << (8*(length/2) - 2)):
+       raise Exception('minimum encoding was not used')
+
+     return v
+
+   The use of variable-size integers for vector lengths allows vectors
+   to grow very large, up to 2^30 bytes.  Implementations should take
+   care not to allow vectors to overflow available storage.  To
+   facilitate debugging of potential interoperability problems,
+   implementations SHOULD provide a clear error when such an overflow
+   condition occurs.
+
+3.  Protocol Overview
+
+   MLS is designed to operate in the context described in [MLS-ARCH].
+   In particular, we assume that the following services are provided:
+
+   *  An Authentication Service (AS) that enables group members to
+      authenticate the credentials presented by other group members.
+
+   *  A Delivery Service (DS) that routes MLS messages among the
+      participants in the protocol.
+
+   MLS assumes a trusted AS but a largely untrusted DS.  Section 16.10
+   describes the impact of compromise or misbehavior of an AS.  MLS is
+   designed to protect the confidentiality and integrity of the group
+   data even in the face of a compromised DS; in general, the DS is only
+   expected to reliably deliver messages.  Section 16.9 describes the
+   impact of compromise or misbehavior of a DS.
+
+   The core functionality of MLS is continuous group authenticated key
+   exchange (AKE).  As with other authenticated key exchange protocols
+   (such as TLS), the participants in the protocol agree on a common
+   secret value, and each participant can verify the identity of the
+   other participants.  That secret can then be used to protect messages
+   sent from one participant in the group to the other participants
+   using the MLS framing layer or can be exported for use with other
+   protocols.  MLS provides group AKE in the sense that there can be
+   more than two participants in the protocol, and continuous group AKE
+   in the sense that the set of participants in the protocol can change
+   over time.
+
+   The core organizing principles of MLS are _groups_ and _epochs_.  A
+   group represents a logical collection of clients that share a common
+   secret value at any given time.  The history of a group is divided
+   into a linear sequence of epochs.  In each epoch, a set of
+   authenticated _members_ agree on an _epoch secret_ that is known only
+   to the members of the group in that epoch.  The set of members
+   involved in the group can change from one epoch to the next, and MLS
+   ensures that only the members in the current epoch have access to the
+   epoch secret.  From the epoch secret, members derive further shared
+   secrets for message encryption, group membership authentication, and
+   so on.
+
+   The creator of an MLS group creates the group's first epoch
+   unilaterally, with no protocol interactions.  Thereafter, the members
+   of the group advance their shared cryptographic state from one epoch
+   to another by exchanging MLS messages.
+
+   *  A _KeyPackage_ object describes a client's capabilities and
+      provides keys that can be used to add the client to a group.
+
+   *  A _Proposal_ message proposes a change to be made in the next
+      epoch, such as adding or removing a member.
+
+   *  A _Commit_ message initiates a new epoch by instructing members of
+      the group to implement a collection of proposals.
+
+   *  A _Welcome_ message provides a new member to the group with the
+      information to initialize their state for the epoch in which they
+      were added or in which they want to add themselves to the group.
+
+   KeyPackage and Welcome messages are used to initiate a group or
+   introduce new members, so they are exchanged between group members
+   and clients not yet in the group.  A client publishes a KeyPackage
+   via the DS, thus enabling other clients to add it to groups.  When a
+   group member wants to add a new member to a group, it uses the new
+   member's KeyPackage to add them and constructs a Welcome message with
+   which the new member can initialize their local state.
+
+   Proposal and Commit messages are sent from one member of a group to
+   the others.  MLS provides a common framing layer for sending messages
+   within a group: A _PublicMessage_ provides sender authentication for
+   unencrypted Proposal and Commit messages.  A _PrivateMessage_
+   provides encryption and authentication for both Proposal/Commit
+   messages as well as any application data.
+
+3.1.  Cryptographic State and Evolution
+
+   The cryptographic state at the core of MLS is divided into three
+   areas of responsibility:
+
+                          .-    ...    -.
+                         |               |
+                         |       |       |
+                         |       |       | Key Schedule
+                         |       V       |
+                         |  epoch_secret |
+.                        |       |       |                             .
+|\ Ratchet               |       |       |                     Secret /|
+| \ Tree                 |       |       |                      Tree / |
+|  \                     |       |       |                          /  |
+|   \                    |       V       |                         /   |
+|    +--> commit_secret --> epoch_secret --> encryption_secret -->+    |
+|   /                    |       |       |                         \   |
+|  /                     |       |       |                          \  |
+| /                      |       |       |                           \ |
+|/                       |       |       |                            \|
+'                        |       V       |                             '
+                         |  epoch_secret |
+                         |       |       |
+                         |       |       |
+                         |       V       |
+                         |               |
+                          '-    ...    -'
+
+              Figure 1: Overview of MLS Group Evolution
+
+   *  A _ratchet tree_ that represents the membership of the group,
+      providing group members a way to authenticate each other and
+      efficiently encrypt messages to subsets of the group.  Each epoch
+      has a distinct ratchet tree.  It seeds the _key schedule_.
+
+   *  A _key schedule_ that describes the chain of key derivations used
+      to progress from epoch to epoch (mainly using the _init_secret_
+      and _epoch_secret_), as well as the derivation of a variety of
+      other secrets (see Table 4).  For example:
+
+      -  An _encryption secret_ that is used to initialize the secret
+         tree for the epoch.
+
+      -  An _exporter secret_ that allows other protocols to leverage
+         MLS as a generic authenticated group key exchange.
+
+      -  A _resumption secret_ that members can use to prove their
+         membership in the group, e.g., when creating a subgroup or a
+         successor group.
+
+   *  A _secret tree_ derived from the key schedule that represents
+      shared secrets used by the members of the group for encrypting and
+      authenticating messages.  Each epoch has a distinct secret tree.
+
+   Each member of the group maintains a partial view of these components
+   of the group's state.  MLS messages are used to initialize these
+   views and keep them in sync as the group transitions between epochs.
+
+   Each new epoch is initiated with a Commit message.  The Commit
+   instructs existing members of the group to update their views of the
+   ratchet tree by applying a set of Proposals, and uses the updated
+   ratchet tree to distribute fresh entropy to the group.  This fresh
+   entropy is provided only to members in the new epoch and not to
+   members who have been removed.  Commits thus maintain the property
+   that the epoch secret is confidential to the members in the current
+   epoch.
+
+   For each Commit that adds one or more members to the group, there are
+   one or more corresponding Welcome messages.  Each Welcome message
+   provides new members with the information they need to initialize
+   their views of the key schedule and ratchet tree, so that these views
+   align with the views held by other members of the group in this
+   epoch.
+
+3.2.  Example Protocol Execution
+
+   There are three major operations in the life of a group:
+
+   *  Adding a member, initiated by a current member;
+
+   *  Updating the keys that represent a member in the tree; and
+
+   *  Removing a member.
+
+   Each of these operations is "proposed" by sending a message of the
+   corresponding type (Add / Update / Remove).  The state of the group
+   is not changed, however, until a Commit message is sent to provide
+   the group with fresh entropy.  In this section, we show each proposal
+   being committed immediately, but in more advanced deployment cases,
+   an application might gather several proposals before committing them
+   all at once.  In the illustrations below, we show the Proposal and
+   Commit messages directly, while in reality they would be sent
+   encapsulated in PublicMessage or PrivateMessage objects.
+
+   Before the initialization of a group, clients publish KeyPackages to
+   a directory provided by the DS (see Figure 2).
+
+                                                    Delivery Service
+                                                            |
+                                                  .--------' '--------.
+                                                 |                     |
+                                                                 Group
+  A                B                C            Directory       Channel
+  |                |                |                |              |
+  | KeyPackageA    |                |                |              |
+  +------------------------------------------------->|              |
+  |                |                |                |              |
+  |                | KeyPackageB    |                |              |
+  |                +-------------------------------->|              |
+  |                |                |                |              |
+  |                |                | KeyPackageC    |              |
+  |                |                +--------------->|              |
+  |                |                |                |              |
+
+    Figure 2: Clients A, B, and C publish KeyPackages to the directory
+
+   Figure 3 shows how these pre-published KeyPackages are used to create
+   a group.  When client A wants to establish a group with clients B and
+   C, it first initializes a group state containing only itself and
+   downloads KeyPackages for B and C.  For each member, A generates an
+   Add proposal and a Commit message to add that member and then
+   broadcasts the two messages to the group.  Client A also generates a
+   Welcome message and sends it directly to the new member (there's no
+   need to send it to the group).  Only after A has received its Commit
+   message back from the Delivery Service does it update its state to
+   reflect the new member's addition.
+
+   Once A has updated its state, the new member has processed the
+   Welcome, and any other group members have processed the Commit, they
+   will all have consistent representations of the group state,
+   including a group secret that is known only to the members the group.
+   The new member will be able to read and send new messages to the
+   group, but messages sent before they were added to the group will not
+   be accessible.
+
+                                                                  Group
+   A              B              C          Directory            Channel
+   |              |              |              |                   |
+   |         KeyPackageB, KeyPackageC           |                   |
+   |<-------------------------------------------+                   |
+   |              |              |              |                   |
+   |              |              |              | Add(A->AB)        |
+   |              |              |              | Commit(Add)       |
+   +--------------------------------------------------------------->|
+   |              |              |              |                   |
+   |  Welcome(B)  |              |              |                   |
+   +------------->|              |              |                   |
+   |              |              |              |                   |
+   |              |              |              | Add(A->AB)        |
+   |              |              |              | Commit(Add)       |
+   |<---------------------------------------------------------------+
+   |              |              |              |                   |
+   |              |              |              |                   |
+   |              |              |              | Add(AB->ABC)      |
+   |              |              |              | Commit(Add)       |
+   +--------------------------------------------------------------->|
+   |              |              |              |                   |
+   |              |  Welcome(C)  |              |                   |
+   +---------------------------->|              |                   |
+   |              |              |              |                   |
+   |              |              |              | Add(AB->ABC)      |
+   |              |              |              | Commit(Add)       |
+   |<---------------------------------------------------------------+
+   |              |<------------------------------------------------+
+   |              |              |              |                   |
+
+          Figure 3: Client A creates a group with clients B and C
+
+   Subsequent additions of group members proceed in the same way.  Any
+   member of the group can download a KeyPackage for a new client,
+   broadcast Add and Commit messages that the current group will use to
+   update their state, and send a Welcome message that the new client
+   can use to initialize its state and join the group.
+
+   To enforce the forward secrecy and post-compromise security of
+   messages, each member periodically updates the keys that represent
+   them to the group.  A member does this by sending a Commit (possibly
+   with no proposals) or by sending an Update message that is committed
+   by another member (see Figure 4).  Once the other members of the
+   group have processed these messages, the group's secrets will be
+   unknown to an attacker that had compromised the secrets corresponding
+   to the sender's leaf in the tree.  At the end of the scenario shown
+   in Figure 4, the group has post-compromise security with respect to
+   both A and B.
+
+   Update messages SHOULD be sent at regular intervals of time as long
+   as the group is active, and members that don't update SHOULD
+   eventually be removed from the group.  It's left to the application
+   to determine an appropriate amount of time between Updates.  Since
+   the purpose of sending an Update is to proactively constrain a
+   compromise window, the right frequency is usually on the order of
+   hours or days, not milliseconds.  For example, an application might
+   send an Update each time a member sends an application message after
+   receiving any message from another member, or daily if no application
+   messages are sent.
+
+   The MLS architecture recommends that MLS be operated over a secure
+   transport (see Section 7.1 of [MLS-ARCH]).  Such transport protocols
+   will typically provide functions such as congestion control that
+   manage the impact of an MLS-using application on other applications
+   sharing the same network.  Applications should take care that they do
+   not send MLS messages at a rate that will cause problems such as
+   network congestion, especially if they are not following the above
+   recommendation (e.g., sending MLS directly over UDP instead).
+
+                                                             Group
+   A              B     ...      Z          Directory        Channel
+   |              |              |              |              |
+   |              | Update(B)    |              |              |
+   |              +------------------------------------------->|
+   |              |              |              | Update(B)    |
+   |<----------------------------------------------------------+
+   |              |<-------------------------------------------+
+   |              |              |<----------------------------+
+   |              |              |              |              |
+   | Commit(Upd)  |              |              |              |
+   +---------------------------------------------------------->|
+   |              |              |              | Commit(Upd)  |
+   |<----------------------------------------------------------+
+   |              |<-------------------------------------------+
+   |              |              |<----------------------------+
+   |              |              |              |              |
+
+        Figure 4: Client B proposes to update its key, and client A
+                            commits the proposal
+
+   Members are removed from the group in a similar way, as shown in
+   Figure 5.  Any member of the group can send a Remove proposal
+   followed by a Commit message.  The Commit message provides new
+   entropy to all members of the group except the removed member.  This
+   new entropy is added to the epoch secret for the new epoch so that it
+   is not known to the removed member.  Note that this does not
+   necessarily imply that any member is actually allowed to evict other
+   members; groups can enforce access control policies on top of these
+   basic mechanisms.
+
+                                                             Group
+   A              B     ...      Z          Directory       Channel
+   |              |              |              |              |
+   |              |              | Remove(B)    |              |
+   |              |              | Commit(Rem)  |              |
+   |              |              +---------------------------->|
+   |              |              |              |              |
+   |              |              |              | Remove(B)    |
+   |              |              |              | Commit(Rem)  |
+   |<----------------------------------------------------------+
+   |              |<-------------------------------------------+
+   |              |              |<----------------------------+
+   |              |              |              |              |
+
+             Figure 5: Client Z removes client B from the group
+
+   Note that the flows in this section are examples; applications can
+   arrange message flows in other ways.  For example:
+
+   *  Welcome messages don't necessarily need to be sent directly to new
+      joiners.  Since they are encrypted to new joiners, they could be
+      distributed more broadly, say if the application only had access
+      to a broadcast channel for the group.
+
+   *  Proposal messages don't need to be immediately sent to all group
+      members.  They need to be available to the committer before
+      generating a Commit, and to other members before processing the
+      Commit.
+
+   *  The sender of a Commit doesn't necessarily have to wait to receive
+      its own Commit back before advancing its state.  It only needs to
+      know that its Commit will be the next one applied by the group,
+      say based on a promise from an orchestration server.
+
+3.3.  External Joins
+
+   In addition to the Welcome-based flow for adding a new member to the
+   group, it is also possible for a new member to join by means of an
+   "external Commit".  This mechanism can be used when the existing
+   members don't have a KeyPackage for the new member, for example, in
+   the case of an "open" group that can be joined by new members without
+   asking permission from existing members.
+
+   Figure 6 shows a typical message flow for an external join.  To
+   enable a new member to join the group in this way, a member of the
+   group (A, B) publishes a GroupInfo object that includes the
+   GroupContext for the group as well as a public key that can be used
+   to encrypt a secret to the existing members of the group.  When the
+   new member Z wishes to join, they download the GroupInfo object and
+   use it to form a Commit of a special form that adds Z to the group
+   (as detailed in Section 12.4.3.2).  The existing members of the group
+   process this external Commit in a similar way to a normal Commit,
+   advancing to a new epoch in which Z is now a member of the group.
+
+                                                             Group
+   A              B              Z          Directory        Channel
+   |              |              |              |              |
+   | GroupInfo    |              |              |              |
+   +------------------------------------------->|              |
+   |              |              | GroupInfo    |              |
+   |              |              |<-------------+              |
+   |              |              |              |              |
+   |              |              | Commit(ExtZ) |              |
+   |              |              +---------------------------->|
+   |              |              |              | Commit(ExtZ) |
+   |<----------------------------------------------------------+
+   |              |<-------------------------------------------+
+   |              |              |<----------------------------+
+   |              |              |              |              |
+
+       Figure 6: Client A publishes a GroupInfo object, and Client Z
+                         uses it to join the group
+
+3.4.  Relationships between Epochs
+
+   A group has a single linear sequence of epochs.  Groups and epochs
+   are generally independent of one another.  However, it can sometimes
+   be useful to link epochs cryptographically, either within a group or
+   across groups.  MLS derives a resumption pre-shared key (PSK) from
+   each epoch to allow entropy extracted from one epoch to be injected
+   into a future epoch.  A group member that wishes to inject a PSK
+   issues a PreSharedKey proposal (Section 12.1.4) describing the PSK to
+   be injected.  When this proposal is committed, the corresponding PSK
+   will be incorporated into the key schedule as described in
+   Section 8.4.
+
+   Linking epochs in this way guarantees that members entering the new
+   epoch agree on a key if and only if they were members of the group
+   during the epoch from which the resumption key was extracted.
+
+   MLS supports two ways to tie a new group to an existing group, which
+   are illustrated in Figures 7 and 8.  Reinitialization closes one
+   group and creates a new group comprising the same members with
+   different parameters.  Branching starts a new group with a subset of
+   the original group's participants (with no effect on the original
+   group).  In both cases, the new group is linked to the old group via
+   a resumption PSK.
+
+   epoch_A_[n-1]
+        |
+        |
+        |<-- ReInit
+        |
+        V
+   epoch_A_[n]           epoch_B_[0]
+        .                     |
+        .  PSK(usage=reinit)  |
+        .....................>|
+                              |
+                              V
+                         epoch_B_[1]
+
+                      Figure 7: Reinitializing a Group
+
+   epoch_A_[n]           epoch_B_[0]
+        |                     |
+        |  PSK(usage=branch)  |
+        |....................>|
+        |                     |
+        V                     V
+   epoch_A_[n+1]         epoch_B_[1]
+
+                        Figure 8: Branching a Group
+
+   Applications may also choose to use resumption PSKs to link epochs in
+   other ways.  For example, Figure 9 shows a case where a resumption
+   PSK from epoch n is injected into epoch n+k.  This demonstrates that
+   the members of the group at epoch n+k were also members at epoch n,
+   irrespective of any changes to these members' keys due to Updates or
+   Commits.
+
+   epoch_A_[n]
+        |
+        |  PSK(usage=application)
+        |.....................
+        |                    .
+        |                    .
+       ...                  ...
+        |                    .
+        |                    .
+        V                    .
+   epoch_A_[n+k-1]           .
+        |                    .
+        |                    .
+        |<....................
+        |
+        V
+   epoch_A_[n+k]
+
+            Figure 9: Reinjecting Entropy from an Earlier Epoch
+
+4.  Ratchet Tree Concepts
+
+   The protocol uses "ratchet trees" for deriving shared secrets among a
+   group of clients.  A ratchet tree is an arrangement of secrets and
+   key pairs among the members of a group in a way that allows for
+   secrets to be efficiently updated to reflect changes in the group.
+
+   Ratchet trees allow a group to efficiently remove any member by
+   encrypting new entropy to a subset of the group.  A ratchet tree
+   assigns shared keys to subgroups of the overall group, so that, for
+   example, encrypting to all but one member of the group requires only
+   log(N) encryptions to subtrees, instead of the N-1 encryptions that
+   would be needed to encrypt to each participant individually (where N
+   is the number of members in the group).
+
+   This remove operation allows MLS to efficiently achieve post-
+   compromise security.  In an Update proposal or a full Commit message,
+   an old (possibly compromised) representation of a member is
+   efficiently removed from the group and replaced with a freshly
+   generated instance.
+
+4.1.  Ratchet Tree Terminology
+
+   Trees consist of _nodes_. A node is a _leaf_ if it has no children;
+   otherwise, it is a _parent_. All parents in our trees have precisely
+   two children, a _left_ child and a _right_ child.  A node is the
+   _root_ of a tree if it has no parent, and _intermediate_ if it has
+   both children and a parent.  The _descendants_ of a node are that
+   node's children, and the descendants of its children.  We say a tree
+   _contains_ a node if that node is a descendant of the root of the
+   tree, or if the node itself is the root of the tree.  Nodes are
+   _siblings_ if they share the same parent.
+
+   A _subtree_ of a tree is the tree given by any node (the _head_ of
+   the subtree) and its descendants.  The _size_ of a tree or subtree is
+   the number of leaf nodes it contains.  For a given parent node, its
+   _left subtree_ is the subtree with its left child as head and its
+   _right subtree_ is the subtree with its right child as head.
+
+   Every tree used in this protocol is a perfect binary tree, that is, a
+   complete balanced binary tree with 2^d leaves all at the same depth
+   d.  This structure is unique for a given depth d.
+
+   There are multiple ways that an implementation might represent a
+   ratchet tree in memory.  A convenient property of left-balanced
+   binary trees (including the complete trees used here) is that they
+   can be represented as an array of nodes, with node relationships
+   computed based on the nodes' indices in the array.  A more
+   traditional representation based on linked node objects may also be
+   used.  Appendices C and D provide some details on how to implement
+   the tree operations required for MLS in these representations.  MLS
+   places no requirements on implementations' internal representations
+   of ratchet trees.  An implementation may use any tree representation
+   and associated algorithms, as long as they produce correct protocol
+   messages.
+
+4.1.1.  Ratchet Tree Nodes
+
+   Each leaf node in a ratchet tree is given an _index_ (or _leaf
+   index_), starting at 0 from the left to 2^d - 1 at the right (for a
+   tree with 2^d leaves).  A tree with 2^d leaves has 2^(d+1) - 1 nodes,
+   including parent nodes.
+
+   Each node in a ratchet tree is either _blank_ (containing no value)
+   or it holds an HPKE public key with some associated data:
+
+   *  A public key (for the HPKE scheme in use; see Section 5.1)
+
+   *  A credential (only for leaf nodes; see Section 5.3)
+
+   *  An ordered list of "unmerged" leaves (see Section 4.2)
+
+   *  A hash of certain information about the node's parent, as of the
+      last time the node was changed (see Section 7.9).
+
+   As described in Section 4.2, different members know different subsets
+   of the set of private keys corresponding to the public keys in nodes
+   in the tree.  The private key corresponding to a parent node is known
+   only to members at leaf nodes that are descendants of that node.  The
+   private key corresponding to a leaf node is known only to the member
+   at that leaf node.  A leaf node is _unmerged_ relative to one of its
+   ancestor nodes if the member at the leaf node does not know the
+   private key corresponding to the ancestor node.
+
+   Every node, regardless of whether the node is blank or populated, has
+   a corresponding _hash_ that summarizes the contents of the subtree
+   below that node.  The rules for computing these hashes are described
+   in Section 7.8.
+
+   The _resolution_ of a node is an ordered list of non-blank nodes that
+   collectively cover all non-blank descendants of the node.  The
+   resolution of the root contains the set of keys that are collectively
+   necessary to encrypt to every node in the group.  The resolution of a
+   node is effectively a depth-first, left-first enumeration of the
+   nearest non-blank nodes below the node:
+
+   *  The resolution of a non-blank node comprises the node itself,
+      followed by its list of unmerged leaves, if any.
+
+   *  The resolution of a blank leaf node is the empty list.
+
+   *  The resolution of a blank intermediate node is the result of
+      concatenating the resolution of its left child with the resolution
+      of its right child, in that order.
+
+   For example, consider the following subtree, where the _ character
+   represents a blank node and unmerged leaves are indicated in square
+   brackets:
+
+                  ...
+                  /
+                 _
+           ______|______
+          /             \
+         X[B]            _
+       __|__           __|__
+      /     \         /     \
+     _       _       Y       _
+    / \     / \     / \     / \
+   A   B   _   D   E   F   _   H
+
+   0   1   2   3   4   5   6   7
+
+             Figure 10: A Tree with Blanks and Unmerged Leaves
+
+   In this tree, we can see all of the above rules in play:
+
+   *  The resolution of node X is the list [X, B].
+
+   *  The resolution of leaf 2 or leaf 6 is the empty list [].
+
+   *  The resolution of top node is the list [X, B, Y, H].
+
+4.1.2.  Paths through a Ratchet Tree
+
+   The _direct path_ of a root is the empty list.  The direct path of
+   any other node is the concatenation of that node's parent along with
+   the parent's direct path.
+
+   The _copath_ of a node is the node's sibling concatenated with the
+   list of siblings of all the nodes in its direct path, excluding the
+   root.
+
+   The _filtered direct path_ of a leaf node L is the node's direct
+   path, with any node removed whose child on the copath of L has an
+   empty resolution (keeping in mind that any unmerged leaves of the
+   copath child count toward its resolution).  The removed nodes do not
+   need their own key pairs because encrypting to the node's key pair
+   would be equivalent to encrypting to its non-copath child.
+
+   For example, consider the following tree (where blank nodes are
+   indicated with _, but also assigned a label for reference):
+
+                 W = root
+                 |
+           .-----+-----.
+          /             \
+         _=U             Y
+         |               |
+       .-+-.           .-+-.
+      /     \         /     \
+     T       _=V     X       _=Z
+    / \     / \     / \     / \
+   A   B   _   _   E   F   G   _=H
+
+   0   1   2   3   4   5   6   7
+
+       Figure 11: A Complete Tree with Five Members, with Labels for
+                             Blank Parent Nodes
+
+   In this tree, the direct paths, copaths, and filtered direct paths
+   for the leaf nodes are as follows:
+
+          +======+=============+=========+======================+
+          | Node | Direct path | Copath  | Filtered Direct Path |
+          +======+=============+=========+======================+
+          | A    | T, U, W     | B, V, Y | T, W                 |
+          +------+-------------+---------+----------------------+
+          | B    | T, U, W     | A, V, Y | T, W                 |
+          +------+-------------+---------+----------------------+
+          | E    | X, Y, W     | F, Z, U | X, Y, W              |
+          +------+-------------+---------+----------------------+
+          | F    | X, Y, W     | E, Z, U | X, Y, W              |
+          +------+-------------+---------+----------------------+
+          | G    | Z, Y, W     | H, X, U | Y, W                 |
+          +------+-------------+---------+----------------------+
+
+                                  Table 2
+
+4.2.  Views of a Ratchet Tree
+
+   We generally assume that each participant maintains a complete and
+   up-to-date view of the public state of the group's ratchet tree,
+   including the public keys for all nodes and the credentials
+   associated with the leaf nodes.
+
+   No participant in an MLS group knows the private key associated with
+   every node in the tree.  Instead, each member is assigned to a leaf
+   of the tree, which determines the subset of private keys it knows.
+   The credential stored at that leaf is one provided by the member.
+
+   In particular, MLS maintains the members' views of the tree in such a
+   way as to maintain the _tree invariant_:
+
+   |  The private key for a node in the tree is known to a member of the
+   |  group only if the node's subtree contains that member's leaf.
+
+   In other words, if a node is not blank, then it holds a public key.
+   The corresponding private key is known only to members occupying
+   leaves below that node.
+
+   The reverse implication is not true: A member may not know the
+   private key of an intermediate node above them.  Such a member has an
+   _unmerged_ leaf at the intermediate node.  Encrypting to an
+   intermediate node requires encrypting to the node's public key, as
+   well as the public keys of all the unmerged leaves below it.  A leaf
+   is unmerged with regard to all of its ancestors when it is first
+   added, because the process of adding the leaf does not give it access
+   to the private keys for all of the nodes above it in the tree.
+   Leaves are "merged" as they receive the private keys for nodes, as
+   described in Section 7.4.
+
+   For example, consider a four-member group (A, B, C, D) where the node
+   above the right two members is blank.  (This is what it would look
+   like if A created a group with B, C, and D.)  Then the public state
+   of the tree and the views of the private keys of the tree held by
+   each participant would be as follows, where _ represents a blank
+   node, ? represents an unknown private key, and pk(X) represents the
+   public key corresponding to the private key X:
+
+            Public Tree
+   ============================
+               pk(ABCD)
+             /          \
+       pk(AB)            _
+        / \             / \
+   pk(A)   pk(B)   pk(C)   pk(D)
+
+
+    Private @ A       Private @ B       Private @ C       Private @ D
+   =============     =============     =============     =============
+        ABCD              ABCD              ABCD              ABCD
+       /   \             /   \             /   \             /   \
+     AB      _         AB      _         ?       _         ?       _
+    / \     / \       / \     / \       / \     / \       / \     / \
+   A   ?   ?   ?     ?   B   ?   ?     ?   ?   C   ?     ?   ?   ?   D
+
+   Note how the tree invariant applies: Each member knows only their own
+   leaf, the private key AB is known only to A and B, and the private
+   key ABCD is known to all four members.  This also illustrates another
+   important point: it is possible for there to be "holes" on the path
+   from a member's leaf to the root in which the member knows the key
+   both above and below a given node, but not for that node, as in the
+   case with D.
+
+5.  Cryptographic Objects
+
+5.1.  Cipher Suites
+
+   Each MLS session uses a single cipher suite that specifies the
+   following primitives to be used in group key computations:
+
+   *  HPKE parameters:
+
+      -  A Key Encapsulation Mechanism (KEM)
+
+      -  A Key Derivation Function (KDF)
+
+      -  An Authenticated Encryption with Associated Data (AEAD)
+         encryption algorithm
+
+   *  A hash algorithm
+
+   *  A Message Authentication Code (MAC) algorithm
+
+   *  A signature algorithm
+
+   MLS uses HPKE for public key encryption [RFC9180].  The DeriveKeyPair
+   function associated to the KEM for the cipher suite maps octet
+   strings to HPKE key pairs.  As in HPKE, MLS assumes that an AEAD
+   algorithm produces a single ciphertext output from AEAD encryption
+   (aligning with [RFC5116]), as opposed to a separate ciphertext and
+   tag.
+
+   Cipher suites are represented with the CipherSuite type.  The cipher
+   suites are defined in Section 17.1.
+
+5.1.1.  Public Keys
+
+   HPKE public keys are opaque values in a format defined by the
+   underlying protocol (see Section 4 of [RFC9180] for more
+   information).
+
+   opaque HPKEPublicKey<V>;
+
+   Signature public keys are likewise represented as opaque values in a
+   format defined by the cipher suite's signature scheme.
+
+   opaque SignaturePublicKey<V>;
+
+   For cipher suites using the Edwards-curve Digital Signature Algorithm
+   (EdDSA) signature schemes (Ed25519 or Ed448), the public key is in
+   the format specified in [RFC8032].
+
+   For cipher suites using the Elliptic Curve Digital Signature
+   Algorithm (ECDSA) with the NIST curves (P-256, P-384, or P-521), the
+   public key is represented as an encoded
+   UncompressedPointRepresentation struct, as defined in [RFC8446].
+
+5.1.2.  Signing
+
+   The signature algorithm specified in a group's cipher suite is the
+   mandatory algorithm to be used for signing messages within the group.
+   It MUST be the same as the signature algorithm specified in the
+   credentials in the leaves of the tree (including the leaf node
+   information in KeyPackages used to add new members).
+
+   The signatures used in this document are encoded as specified in
+   [RFC8446].  In particular, ECDSA signatures are DER encoded, and
+   EdDSA signatures are defined as the concatenation of R and S, as
+   specified in [RFC8032].
+
+   To disambiguate different signatures used in MLS, each signed value
+   is prefixed by a label as shown below:
+
+   SignWithLabel(SignatureKey, Label, Content) =
+       Signature.Sign(SignatureKey, SignContent)
+
+   VerifyWithLabel(VerificationKey, Label, Content, SignatureValue) =
+       Signature.Verify(VerificationKey, SignContent, SignatureValue)
+
+   Where SignContent is specified as:
+
+   struct {
+       opaque label<V>;
+       opaque content<V>;
+   } SignContent;
+
+   And its fields are set to:
+
+   label = "MLS 1.0 " + Label;
+   content = Content;
+
+   The functions Signature.Sign and Signature.Verify are defined by the
+   signature algorithm.  If MLS extensions require signatures by group
+   members, they should reuse the SignWithLabel construction, using a
+   distinct label.  To avoid collisions in these labels, an IANA
+   registry is defined in Section 17.6.
+
+5.1.3.  Public Key Encryption
+
+   As with signing, MLS includes a label and context in encryption
+   operations to avoid confusion between ciphertexts produced for
+   different purposes.  Encryption and decryption including this label
+   and context are done as follows:
+
+   EncryptWithLabel(PublicKey, Label, Context, Plaintext) =
+     SealBase(PublicKey, EncryptContext, "", Plaintext)
+
+   DecryptWithLabel(PrivateKey, Label, Context, KEMOutput, Ciphertext) =
+     OpenBase(KEMOutput, PrivateKey, EncryptContext, "", Ciphertext)
+
+   Where EncryptContext is specified as:
+
+   struct {
+     opaque label<V>;
+     opaque context<V>;
+   } EncryptContext;
+
+   And its fields are set to:
+
+   label = "MLS 1.0 " + Label;
+   context = Context;
+
+   The functions SealBase and OpenBase are defined in Section 6.1 of
+   [RFC9180] (with "Base" as the MODE), using the HPKE algorithms
+   specified by the group's cipher suite.  If MLS extensions require
+   HPKE encryption operations, they should reuse the EncryptWithLabel
+   construction, using a distinct label.  To avoid collisions in these
+   labels, an IANA registry is defined in Section 17.7.
+
+5.2.  Hash-Based Identifiers
+
+   Some MLS messages refer to other MLS objects by hash.  For example,
+   Welcome messages refer to KeyPackages for the members being welcomed,
+   and Commits refer to Proposals they cover.  These identifiers are
+   computed as follows:
+
+   opaque HashReference<V>;
+
+   HashReference KeyPackageRef;
+   HashReference ProposalRef;
+
+   MakeKeyPackageRef(value)
+     = RefHash("MLS 1.0 KeyPackage Reference", value)
+
+   MakeProposalRef(value)
+     = RefHash("MLS 1.0 Proposal Reference", value)
+
+   RefHash(label, value) = Hash(RefHashInput)
+
+   Where RefHashInput is defined as:
+
+   struct {
+     opaque label<V>;
+     opaque value<V>;
+   } RefHashInput;
+
+   And its fields are set to:
+
+   label = label;
+   value = value;
+
+   For a KeyPackageRef, the value input is the encoded KeyPackage, and
+   the cipher suite specified in the KeyPackage determines the KDF used.
+   For a ProposalRef, the value input is the AuthenticatedContent
+   carrying the Proposal.  In the latter two cases, the KDF is
+   determined by the group's cipher suite.
+
+5.3.  Credentials
+
+   Each member of a group presents a credential that provides one or
+   more identities for the member and associates them with the member's
+   signing key.  The identities and signing key are verified by the
+   Authentication Service in use for a group.
+
+   It is up to the application to decide which identifiers to use at the
+   application level.  For example, a certificate in an X509Credential
+   may attest to several domain names or email addresses in its
+   subjectAltName extension.  An application may decide to present all
+   of these to a user, or if it knows a "desired" domain name or email
+   address, it can check that the desired identifier is among those
+   attested.  Using the terminology from [RFC6125], a credential
+   provides "presented identifiers", and it is up to the application to
+   supply a "reference identifier" for the authenticated client, if any.
+
+   // See the "MLS Credential Types" IANA registry for values
+   uint16 CredentialType;
+
+   struct {
+       opaque cert_data<V>;
+   } Certificate;
+
+   struct {
+       CredentialType credential_type;
+       select (Credential.credential_type) {
+           case basic:
+               opaque identity<V>;
+
+           case x509:
+               Certificate certificates<V>;
+       };
+   } Credential;
+
+   A "basic" credential is a bare assertion of an identity, without any
+   additional information.  The format of the encoded identity is
+   defined by the application.
+
+   For an X.509 credential, each entry in the certificates field
+   represents a single DER-encoded X.509 certificate.  The chain is
+   ordered such that the first entry (certificates[0]) is the end-entity
+   certificate.  The public key encoded in the subjectPublicKeyInfo of
+   the end-entity certificate MUST be identical to the signature_key in
+   the LeafNode containing this credential.  A chain MAY omit any non-
+   leaf certificates that supported peers are known to already possess.
+
+5.3.1.  Credential Validation
+
+   The application using MLS is responsible for specifying which
+   identifiers it finds acceptable for each member in a group.  In other
+   words, following the model that [RFC6125] describes for TLS, the
+   application maintains a list of "reference identifiers" for the
+   members of a group, and the credentials provide "presented
+   identifiers".  A member of a group is authenticated by first
+   validating that the member's credential legitimately represents some
+   presented identifiers, and then ensuring that the reference
+   identifiers for the member are authenticated by those presented
+   identifiers.
+
+   The parts of the system that perform these functions are collectively
+   referred to as the Authentication Service (AS) [MLS-ARCH].  A
+   member's credential is said to be _validated with the AS_ when the AS
+   verifies that the credential's presented identifiers are correctly
+   associated with the signature_key field in the member's LeafNode, and
+   that those identifiers match the reference identifiers for the
+   member.
+
+   Whenever a new credential is introduced in the group, it MUST be
+   validated with the AS.  In particular, at the following events in the
+   protocol:
+
+   *  When a member receives a KeyPackage that it will use in an Add
+      proposal to add a new member to the group
+
+   *  When a member receives a GroupInfo object that it will use to join
+      a group, either via a Welcome or via an external Commit
+
+   *  When a member receives an Add proposal adding a member to the
+      group
+
+   *  When a member receives an Update proposal whose LeafNode has a new
+      credential for the member
+
+   *  When a member receives a Commit with an UpdatePath whose LeafNode
+      has a new credential for the committer
+
+   *  When an external_senders extension is added to the group
+
+   *  When an existing external_senders extension is updated
+
+   In cases where a member's credential is being replaced, such as the
+   Update and Commit cases above, the AS MUST also verify that the set
+   of presented identifiers in the new credential is valid as a
+   successor to the set of presented identifiers in the old credential,
+   according to the application's policy.
+
+5.3.2.  Credential Expiry and Revocation
+
+   In some credential schemes, a valid credential can "expire" or become
+   invalid after a certain point in time.  For example, each X.509
+   certificate has a notAfter field, expressing a time after which the
+   certificate is not valid.
+
+   Expired credentials can cause operational problems in light of the
+   validation requirements of Section 5.3.1.  Applications can apply
+   some operational practices and adaptations to Authentication Service
+   policies to moderate these impacts.
+
+   In general, to avoid operational problems such as new joiners
+   rejecting expired credentials in a group, applications that use such
+   credentials should ensure to the extent practical that all of the
+   credentials in use in a group are valid at all times.
+
+   If a member finds that its credential has expired (or will soon), it
+   should issue an Update or Commit that replaces it with a valid
+   credential.  For this reason, members SHOULD accept Update proposals
+   and Commits issued by members with expired credentials, if the
+   credential in the Update or Commit is valid.
+
+   Similarly, when a client is processing messages sent some time in the
+   past (e.g., syncing up with a group after being offline), the client
+   SHOULD accept signatures from members with expired credentials, since
+   the credential may have been valid at the time the message was sent.
+
+   If a member finds that another member's credential has expired, they
+   may issue a Remove that removes that member.  For example, an
+   application could require a member preparing to issue a Commit to
+   check the tree for expired credentials and include Remove proposals
+   for those members in its Commit.  In situations where the group tree
+   is known to the DS, the DS could also monitor the tree for expired
+   credentials and issue external Remove proposals.
+
+   Some credential schemes also allow credentials to be revoked.
+   Revocation is similar to expiry in that a previously valid credential
+   becomes invalid.  As such, most of the considerations above also
+   apply to revoked credentials.  However, applications may want to
+   treat revoked credentials differently, e.g., by removing members with
+   revoked credentials while allowing members with expired credentials
+   time to update.
+
+5.3.3.  Uniquely Identifying Clients
+
+   MLS implementations will presumably provide applications with a way
+   to request protocol operations with regard to other clients (e.g.,
+   removing clients).  Such functions will need to refer to the other
+   clients using some identifier.  MLS clients have a few types of
+   identifiers, with different operational properties.
+
+   Internally to the protocol, group members are uniquely identified by
+   their leaf index.  However, a leaf index is only valid for referring
+   to members in a given epoch.  The same leaf index may represent a
+   different member, or no member at all, in a subsequent epoch.
+
+   The Credentials presented by the clients in a group authenticate
+   application-level identifiers for the clients.  However, these
+   identifiers may not uniquely identify clients.  For example, if a
+   user has multiple devices that are all present in an MLS group, then
+   those devices' clients could all present the user's application-layer
+   identifiers.
+
+   If needed, applications may add application-specific identifiers to
+   the extensions field of a LeafNode object with the application_id
+   extension.
+
+   opaque application_id<V>;
+
+   However, applications MUST NOT rely on the data in an application_id
+   extension as if it were authenticated by the Authentication Service,
+   and SHOULD gracefully handle cases where the identifier presented is
+   not unique.
+
+6.  Message Framing
+
+   Handshake and application messages use a common framing structure.
+   This framing provides encryption to ensure confidentiality within the
+   group, as well as signing to authenticate the sender.
+
+   In most of the protocol, messages are handled in the form of
+   AuthenticatedContent objects.  These structures contain the content
+   of the message itself as well as information to authenticate the
+   sender (see Section 6.1).  The additional protections required to
+   transmit these messages over an untrusted channel (group membership
+   authentication or AEAD encryption) are added by encoding the
+   AuthenticatedContent as a PublicMessage or PrivateMessage message,
+   which can then be sent as an MLSMessage.  Likewise, these protections
+   are enforced (via membership verification or AEAD decryption) when
+   decoding a PublicMessage or PrivateMessage into an
+   AuthenticatedContent object.
+
+   PrivateMessage represents a signed and encrypted message, with
+   protections for both the content of the message and related metadata.
+   PublicMessage represents a message that is only signed, and not
+   encrypted.  Applications MUST use PrivateMessage to encrypt
+   application messages and SHOULD use PrivateMessage to encode
+   handshake messages, but they MAY transmit handshake messages encoded
+   as PublicMessage objects in cases where it is necessary for the
+   Delivery Service to examine such messages.
+
+   enum {
+       reserved(0),
+       mls10(1),
+       (65535)
+   } ProtocolVersion;
+
+   enum {
+       reserved(0),
+       application(1),
+       proposal(2),
+       commit(3),
+       (255)
+   } ContentType;
+
+   enum {
+       reserved(0),
+       member(1),
+       external(2),
+       new_member_proposal(3),
+       new_member_commit(4),
+       (255)
+   } SenderType;
+
+   struct {
+       SenderType sender_type;
+       select (Sender.sender_type) {
+           case member:
+               uint32 leaf_index;
+           case external:
+               uint32 sender_index;
+           case new_member_commit:
+           case new_member_proposal:
+               struct{};
+       };
+   } Sender;
+
+   // See the "MLS Wire Formats" IANA registry for values
+   uint16 WireFormat;
+
+   struct {
+       opaque group_id<V>;
+       uint64 epoch;
+       Sender sender;
+       opaque authenticated_data<V>;
+
+       ContentType content_type;
+       select (FramedContent.content_type) {
+           case application:
+             opaque application_data<V>;
+           case proposal:
+             Proposal proposal;
+           case commit:
+             Commit commit;
+       };
+   } FramedContent;
+
+   struct {
+       ProtocolVersion version = mls10;
+       WireFormat wire_format;
+       select (MLSMessage.wire_format) {
+           case mls_public_message:
+               PublicMessage public_message;
+           case mls_private_message:
+               PrivateMessage private_message;
+           case mls_welcome:
+               Welcome welcome;
+           case mls_group_info:
+               GroupInfo group_info;
+           case mls_key_package:
+               KeyPackage key_package;
+       };
+   } MLSMessage;
+
+   Messages from senders that aren't in the group are sent as
+   PublicMessage.  See Sections 12.1.8 and 12.4.3.2 for more details.
+
+   The following structure is used to fully describe the data
+   transmitted in plaintexts or ciphertexts.
+
+   struct {
+       WireFormat wire_format;
+       FramedContent content;
+       FramedContentAuthData auth;
+   } AuthenticatedContent;
+
+   The following figure illustrates how the various structures described
+   in this section relate to each other, and the high-level operations
+   used to produce and consume them:
+
+       Proposal        Commit     Application Data
+          |              |              |
+          +--------------+--------------+
+                         |
+                         V
+                  FramedContent
+                      |  |                -.
+             +--------+  |                  |
+             |           |                  |
+             V           |                  +-- Asymmetric
+   FramedContentAuthData |                  |   Sign / Verify
+             |           |                  |
+             +--------+  |                  |
+                      |  |                  |
+                      V  V                -'
+                AuthenticatedContent
+                         |                -.
+                +--------+--------+         |
+                |                 |         +-- Symmetric
+                V                 V         |   Protect / Unprotect
+          PublicMessage    PrivateMessage -'
+                |                 |
+                |                 |  Welcome  KeyPackage  GroupInfo
+                |                 |     |          |          |
+                +-----------------+-----+----------+----------+
+                                  |
+                                  V
+                              MLSMessage
+
+                 Figure 12: Relationships among MLS Objects
+
+6.1.  Content Authentication
+
+   FramedContent is authenticated using the FramedContentAuthData
+   structure.
+
+   struct {
+       ProtocolVersion version = mls10;
+       WireFormat wire_format;
+       FramedContent content;
+       select (FramedContentTBS.content.sender.sender_type) {
+           case member:
+           case new_member_commit:
+               GroupContext context;
+           case external:
+           case new_member_proposal:
+               struct{};
+       };
+   } FramedContentTBS;
+
+   opaque MAC<V>;
+
+   struct {
+       /* SignWithLabel(., "FramedContentTBS", FramedContentTBS) */
+       opaque signature<V>;
+       select (FramedContent.content_type) {
+           case commit:
+               /*
+                 MAC(confirmation_key,
+                     GroupContext.confirmed_transcript_hash)
+               */
+               MAC confirmation_tag;
+           case application:
+           case proposal:
+               struct{};
+       };
+   } FramedContentAuthData;
+
+   The signature is computed using SignWithLabel with label
+   "FramedContentTBS" and with a content that covers the message content
+   and the wire format that will be used for this message.  If the
+   sender's sender_type is member, the content also covers the
+   GroupContext for the current epoch so that signatures are specific to
+   a given group and epoch.
+
+   The sender MUST use the private key corresponding to the following
+   signature key depending on the sender's sender_type:
+
+   *  member: The signature key contained in the LeafNode at the index
+      indicated by leaf_index in the ratchet tree.
+
+   *  external: The signature key at the index indicated by sender_index
+      in the external_senders group context extension (see
+      Section 12.1.8.1).  The content_type of the message MUST be
+      proposal and the proposal_type MUST be a value that is allowed for
+      external senders.
+
+   *  new_member_commit: The signature key in the LeafNode in the
+      Commit's path (see Section 12.4.3.2).  The content_type of the
+      message MUST be commit.
+
+   *  new_member_proposal: The signature key in the LeafNode in the
+      KeyPackage embedded in an external Add proposal.  The content_type
+      of the message MUST be proposal and the proposal_type of the
+      Proposal MUST be add.
+
+   Recipients of an MLSMessage MUST verify the signature with the key
+   depending on the sender_type of the sender as described above.
+
+   The confirmation tag value confirms that the members of the group
+   have arrived at the same state of the group.  A FramedContentAuthData
+   is said to be valid when both the signature and confirmation_tag
+   fields are valid.
+
+6.2.  Encoding and Decoding a Public Message
+
+   Messages that are authenticated but not encrypted are encoded using
+   the PublicMessage structure.
+
+   struct {
+       FramedContent content;
+       FramedContentAuthData auth;
+       select (PublicMessage.content.sender.sender_type) {
+           case member:
+               MAC membership_tag;
+           case external:
+           case new_member_commit:
+           case new_member_proposal:
+               struct{};
+       };
+   } PublicMessage;
+
+   The membership_tag field in the PublicMessage object authenticates
+   the sender's membership in the group.  For messages sent by members,
+   it MUST be set to the following value:
+
+   struct {
+     FramedContentTBS content_tbs;
+     FramedContentAuthData auth;
+   } AuthenticatedContentTBM;
+
+   membership_tag = MAC(membership_key, AuthenticatedContentTBM)
+
+   When decoding a PublicMessage into an AuthenticatedContent, the
+   application MUST check membership_tag and MUST check that the
+   FramedContentAuthData is valid.
+
+6.3.  Encoding and Decoding a Private Message
+
+   Authenticated and encrypted messages are encoded using the
+   PrivateMessage structure.
+
+   struct {
+       opaque group_id<V>;
+       uint64 epoch;
+       ContentType content_type;
+       opaque authenticated_data<V>;
+       opaque encrypted_sender_data<V>;
+       opaque ciphertext<V>;
+   } PrivateMessage;
+
+   encrypted_sender_data and ciphertext are encrypted using the AEAD
+   function specified by the cipher suite in use, using the SenderData
+   and PrivateMessageContent structures as input.
+
+6.3.1.  Content Encryption
+
+   Content to be encrypted is encoded in a PrivateMessageContent
+   structure.
+
+   struct {
+       select (PrivateMessage.content_type) {
+           case application:
+             opaque application_data<V>;
+
+           case proposal:
+             Proposal proposal;
+
+           case commit:
+             Commit commit;
+       };
+
+       FramedContentAuthData auth;
+       opaque padding[length_of_padding];
+   } PrivateMessageContent;
+
+   The padding field is set by the sender, by first encoding the content
+   (via the select) and the auth field, and then appending the chosen
+   number of zero bytes.  A receiver identifies the padding field in a
+   plaintext decoded from PrivateMessage.ciphertext by first decoding
+   the content and the auth field; then the padding field comprises any
+   remaining octets of plaintext.  The padding field MUST be filled with
+   all zero bytes.  A receiver MUST verify that there are no non-zero
+   bytes in the padding field, and if this check fails, the enclosing
+   PrivateMessage MUST be rejected as malformed.  This check ensures
+   that the padding process is deterministic, so that, for example,
+   padding cannot be used as a covert channel.
+
+   In the MLS key schedule, the sender creates two distinct key ratchets
+   for handshake and application messages for each member of the group.
+   When encrypting a message, the sender looks at the ratchets it
+   derived for its own member and chooses an unused generation from
+   either the handshake ratchet or the application ratchet, depending on
+   the content type of the message.  This generation of the ratchet is
+   used to derive a provisional nonce and key.
+
+   Before use in the encryption operation, the nonce is XORed with a
+   fresh random value to guard against reuse.  Because the key schedule
+   generates nonces deterministically, a client MUST keep persistent
+   state as to where in the key schedule it is; if this persistent state
+   is lost or corrupted, a client might reuse a generation that has
+   already been used, causing reuse of a key/nonce pair.
+
+   To avoid this situation, the sender of a message MUST generate a
+   fresh random four-byte "reuse guard" value and XOR it with the first
+   four bytes of the nonce from the key schedule before using the nonce
+   for encryption.  The sender MUST include the reuse guard in the
+   reuse_guard field of the sender data object, so that the recipient of
+   the message can use it to compute the nonce to be used for
+   decryption.
+
+   +-+-+-+-+---------...---+
+   |   Key Schedule Nonce  |
+   +-+-+-+-+---------...---+
+              XOR
+   +-+-+-+-+---------...---+
+   | Guard |       0       |
+   +-+-+-+-+---------...---+
+              ===
+   +-+-+-+-+---------...---+
+   | Encrypt/Decrypt Nonce |
+   +-+-+-+-+---------...---+
+
+   The Additional Authenticated Data (AAD) input to the encryption
+   contains an object of the following form, with the values used to
+   identify the key and nonce:
+
+   struct {
+       opaque group_id<V>;
+       uint64 epoch;
+       ContentType content_type;
+       opaque authenticated_data<V>;
+   } PrivateContentAAD;
+
+   When decoding a PrivateMessageContent, the application MUST check
+   that the FramedContentAuthData is valid.
+
+   It is up to the application to decide what authenticated_data to
+   provide and how much padding to add to a given message (if any).  The
+   overall size of the AAD and ciphertext MUST fit within the limits
+   established for the group's AEAD algorithm in [CFRG-AEAD-LIMITS].
+
+6.3.2.  Sender Data Encryption
+
+   The "sender data" used to look up the key for content encryption is
+   encrypted with the cipher suite's AEAD with a key and nonce derived
+   from both the sender_data_secret and a sample of the encrypted
+   content.  Before being encrypted, the sender data is encoded as an
+   object of the following form:
+
+   struct {
+       uint32 leaf_index;
+       uint32 generation;
+       opaque reuse_guard[4];
+   } SenderData;
+
+   When constructing a SenderData object from a Sender object, the
+   sender MUST verify Sender.sender_type is member and use
+   Sender.leaf_index for SenderData.leaf_index.
+
+   The reuse_guard field contains a fresh random value used to avoid
+   nonce reuse in the case of state loss or corruption, as described in
+   Section 6.3.1.
+
+   The key and nonce provided to the AEAD are computed as the KDF of the
+   first KDF.Nh bytes of the ciphertext generated in the previous
+   section.  If the length of the ciphertext is less than KDF.Nh, the
+   whole ciphertext is used.  In pseudocode, the key and nonce are
+   derived as:
+
+   ciphertext_sample = ciphertext[0..KDF.Nh-1]
+
+   sender_data_key = ExpandWithLabel(sender_data_secret, "key",
+                         ciphertext_sample, AEAD.Nk)
+   sender_data_nonce = ExpandWithLabel(sender_data_secret, "nonce",
+                         ciphertext_sample, AEAD.Nn)
+
+   The AAD for the SenderData ciphertext is the first three fields of
+   PrivateMessage:
+
+   struct {
+       opaque group_id<V>;
+       uint64 epoch;
+       ContentType content_type;
+   } SenderDataAAD;
+
+   When parsing a SenderData struct as part of message decryption, the
+   recipient MUST verify that the leaf index indicated in the leaf_index
+   field identifies a non-blank node.
+
+7.  Ratchet Tree Operations
+
+   The ratchet tree for an epoch describes the membership of a group in
+   that epoch, providing public key encryption (HPKE) keys that can be
+   used to encrypt to subsets of the group as well as information to
+   authenticate the members.  In order to reflect changes to the
+   membership of the group from one epoch to the next, corresponding
+   changes are made to the ratchet tree.  In this section, we describe
+   the content of the tree and the required operations.
+
+7.1.  Parent Node Contents
+
+   As discussed in Section 4.1.1, the nodes of a ratchet tree contain
+   several types of data describing individual members (for leaf nodes)
+   or subgroups of the group (for parent nodes).  Parent nodes are
+   simpler:
+
+   struct {
+       HPKEPublicKey encryption_key;
+       opaque parent_hash<V>;
+       uint32 unmerged_leaves<V>;
+   } ParentNode;
+
+   The encryption_key field contains an HPKE public key whose private
+   key is held only by the members at the leaves among its descendants.
+   The parent_hash field contains a hash of this node's parent node, as
+   described in Section 7.9.  The unmerged_leaves field lists the leaves
+   under this parent node that are unmerged, according to their indices
+   among all the leaves in the tree.  The entries in the unmerged_leaves
+   vector MUST be sorted in increasing order.
+
+7.2.  Leaf Node Contents
+
+   A leaf node in the tree describes all the details of an individual
+   client's appearance in the group, signed by that client.  It is also
+   used in client KeyPackage objects to store the information that will
+   be needed to add a client to a group.
+
+   enum {
+       reserved(0),
+       key_package(1),
+       update(2),
+       commit(3),
+       (255)
+   } LeafNodeSource;
+
+   struct {
+       ProtocolVersion versions<V>;
+       CipherSuite cipher_suites<V>;
+       ExtensionType extensions<V>;
+       ProposalType proposals<V>;
+       CredentialType credentials<V>;
+   } Capabilities;
+
+   struct {
+       uint64 not_before;
+       uint64 not_after;
+   } Lifetime;
+
+   // See the "MLS Extension Types" IANA registry for values
+   uint16 ExtensionType;
+
+   struct {
+       ExtensionType extension_type;
+       opaque extension_data<V>;
+   } Extension;
+
+   struct {
+       HPKEPublicKey encryption_key;
+       SignaturePublicKey signature_key;
+       Credential credential;
+       Capabilities capabilities;
+
+       LeafNodeSource leaf_node_source;
+       select (LeafNode.leaf_node_source) {
+           case key_package:
+               Lifetime lifetime;
+
+           case update:
+               struct{};
+
+           case commit:
+               opaque parent_hash<V>;
+       };
+
+       Extension extensions<V>;
+       /* SignWithLabel(., "LeafNodeTBS", LeafNodeTBS) */
+       opaque signature<V>;
+   } LeafNode;
+
+   struct {
+       HPKEPublicKey encryption_key;
+       SignaturePublicKey signature_key;
+       Credential credential;
+       Capabilities capabilities;
+
+       LeafNodeSource leaf_node_source;
+       select (LeafNodeTBS.leaf_node_source) {
+           case key_package:
+               Lifetime lifetime;
+
+           case update:
+               struct{};
+
+           case commit:
+               opaque parent_hash<V>;
+       };
+
+       Extension extensions<V>;
+
+       select (LeafNodeTBS.leaf_node_source) {
+           case key_package:
+               struct{};
+
+           case update:
+               opaque group_id<V>;
+               uint32 leaf_index;
+
+           case commit:
+               opaque group_id<V>;
+               uint32 leaf_index;
+       };
+   } LeafNodeTBS;
+
+   The encryption_key field contains an HPKE public key whose private
+   key is held only by the member occupying this leaf (or in the case of
+   a LeafNode in a KeyPackage object, the issuer of the KeyPackage).
+   The signature_key field contains the member's public signing key.
+   The credential field contains information authenticating both the
+   member's identity and the provided signing key, as described in
+   Section 5.3.
+
+   The capabilities field indicates the protocol features that the
+   client supports, including protocol versions, cipher suites,
+   credential types, non-default proposal types, and non-default
+   extension types.  The following proposal and extension types are
+   considered "default" and MUST NOT be listed:
+
+   *  Proposal types:
+
+      -  0x0001 - add
+
+      -  0x0002 - update
+
+      -  0x0003 - remove
+
+      -  0x0004 - psk
+
+      -  0x0005 - reinit
+
+      -  0x0006 - external_init
+
+      -  0x0007 - group_context_extensions
+
+   *  Extension types:
+
+      -  0x0001 - application_id
+
+      -  0x0002 - ratchet_tree
+
+      -  0x0003 - required_capabilities
+
+      -  0x0004 - external_pub
+
+      -  0x0005 - external_senders
+
+   There are no default values for the other fields of a capabilities
+   object.  The client MUST list all values for the respective
+   parameters that it supports.
+
+   The types of any non-default extensions that appear in the extensions
+   field of a LeafNode MUST be included in the extensions field of the
+   capabilities field, and the credential type used in the LeafNode MUST
+   be included in the credentials field of the capabilities field.
+
+   As discussed in Section 13, unknown values in capabilities MUST be
+   ignored, and the creator of a capabilities field SHOULD include some
+   random GREASE values to help ensure that other clients correctly
+   ignore unknown values.
+
+   The leaf_node_source field indicates how this LeafNode came to be
+   added to the tree.  This signal tells other members of the group
+   whether the leaf node is required to have a lifetime or parent_hash,
+   and whether the group_id is added as context to the signature.  These
+   fields are included selectively because the client creating a
+   LeafNode is not always able to compute all of them.  For example, a
+   KeyPackage is created before the client knows which group it will be
+   used with, so its signature can't bind to a group_id.
+
+   In the case where the leaf was added to the tree based on a pre-
+   published KeyPackage, the lifetime field represents the times between
+   which clients will consider a LeafNode valid.  These times are
+   represented as absolute times, measured in seconds since the Unix
+   epoch (1970-01-01T00:00:00Z).  Applications MUST define a maximum
+   total lifetime that is acceptable for a LeafNode, and reject any
+   LeafNode where the total lifetime is longer than this duration.  In
+   order to avoid disagreements about whether a LeafNode has a valid
+   lifetime, the clients in a group SHOULD maintain time synchronization
+   (e.g., using the Network Time Protocol [RFC5905]).
+
+   In the case where the leaf node was inserted into the tree via a
+   Commit message, the parent_hash field contains the parent hash for
+   this leaf node (see Section 7.9).
+
+   The LeafNodeTBS structure covers the fields above the signature in
+   the LeafNode.  In addition, when the leaf node was created in the
+   context of a group (the update and commit cases), the group ID of the
+   group is added as context to the signature.
+
+   LeafNode objects stored in the group's ratchet tree are updated
+   according to the evolution of the tree.  Each modification of
+   LeafNode content MUST be reflected by a change in its signature.
+   This allows other members to verify the validity of the LeafNode at
+   any time, particularly in the case of a newcomer joining the group.
+
+7.3.  Leaf Node Validation
+
+   The validity of a LeafNode needs to be verified at the following
+   stages:
+
+   *  When a LeafNode is downloaded in a KeyPackage, before it is used
+      to add the client to the group
+
+   *  When a LeafNode is received by a group member in an Add, Update,
+      or Commit message
+
+   *  When a client validates a ratchet tree, e.g., when joining a group
+      or after processing a Commit
+
+   The client verifies the validity of a LeafNode using the following
+   steps:
+
+   *  Verify that the credential in the LeafNode is valid, as described
+      in Section 5.3.1.
+
+   *  Verify that the signature on the LeafNode is valid using
+      signature_key.
+
+   *  Verify that the LeafNode is compatible with the group's
+      parameters.  If the GroupContext has a required_capabilities
+      extension, then the required extensions, proposals, and credential
+      types MUST be listed in the LeafNode's capabilities field.
+
+   *  Verify that the credential type is supported by all members of the
+      group, as specified by the capabilities field of each member's
+      LeafNode, and that the capabilities field of this LeafNode
+      indicates support for all the credential types currently in use by
+      other members.
+
+   *  Verify the lifetime field:
+
+      -  If the LeafNode appears in a message being sent by the client,
+         e.g., a Proposal or a Commit, then the client MUST verify that
+         the current time is within the range of the lifetime field.
+
+      -  If instead the LeafNode appears in a message being received by
+         the client, e.g., a Proposal, a Commit, or a ratchet tree of
+         the group the client is joining, it is RECOMMENDED that the
+         client verifies that the current time is within the range of
+         the lifetime field.  (This check is not mandatory because the
+         LeafNode might have expired in the time between when the
+         message was sent and when it was received.)
+
+   *  Verify that the extensions in the LeafNode are supported by
+      checking that the ID for each extension in the extensions field is
+      listed in the capabilities.extensions field of the LeafNode.
+
+   *  Verify the leaf_node_source field:
+
+      -  If the LeafNode appears in a KeyPackage, verify that
+         leaf_node_source is set to key_package.
+
+      -  If the LeafNode appears in an Update proposal, verify that
+         leaf_node_source is set to update and that encryption_key
+         represents a different public key than the encryption_key in
+         the leaf node being replaced by the Update proposal.
+
+      -  If the LeafNode appears in the leaf_node value of the
+         UpdatePath in a Commit, verify that leaf_node_source is set to
+         commit.
+
+   *  Verify that the following fields are unique among the members of
+      the group:
+
+      -  signature_key
+
+      -  encryption_key
+
+7.4.  Ratchet Tree Evolution
+
+   Whenever a member initiates an epoch change (i.e., commits; see
+   Section 12.4), they may need to refresh the key pairs of their leaf
+   and of the nodes on their leaf's direct path in order to maintain
+   forward secrecy and post-compromise security.
+
+   The member initiating the epoch change generates the fresh key pairs
+   using the following procedure.  The procedure is designed in a way
+   that allows group members to efficiently communicate the fresh secret
+   keys to other group members, as described in Section 7.6.
+
+   A member updates the nodes along its direct path as follows:
+
+   *  Blank all the nodes on the direct path from the leaf to the root.
+
+   *  Generate a fresh HPKE key pair for the leaf.
+
+   *  Generate a sequence of path secrets, one for each node on the
+      leaf's filtered direct path, as follows.  In this setting,
+      path_secret[0] refers to the first parent node in the filtered
+      direct path, path_secret[1] to the second parent node, and so on.
+
+   path_secret[0] is sampled at random
+   path_secret[n] = DeriveSecret(path_secret[n-1], "path")
+
+   *  Compute the sequence of HPKE key pairs (node_priv,node_pub), one
+      for each node on the leaf's direct path, as follows.
+
+   node_secret[n] = DeriveSecret(path_secret[n], "node")
+   node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
+
+   The node secret is derived as a temporary intermediate secret so that
+   each secret is only used with one algorithm: The path secret is used
+   as an input to DeriveSecret, and the node secret is used as an input
+   to DeriveKeyPair.
+
+   For example, suppose there is a group with four members, with C an
+   unmerged leaf at Z:
+
+         Y
+         |
+       .-+-.
+      /     \
+     X       Z[C]
+    / \     / \
+   A   B   C   D
+
+   0   1   2   3
+
+               Figure 13: A Full Tree with One Unmerged Leaf
+
+   If member B subsequently generates an UpdatePath based on a secret
+   "leaf_secret", then it would generate the following sequence of path
+   secrets:
+
+   path_secret[1] ---> node_secret[1] -------> node_priv[1], node_pub[1]
+
+        ^
+        |
+        |
+   path_secret[0] ---> node_secret[0] -------> node_priv[0], node_pub[0]
+
+        ^
+        |
+        |
+   leaf_secret ------> leaf_node_secret --+--> leaf_priv, leaf_pub
+                                              |                   |
+                                               '-------. .-------'
+                                                        |
+                                                    leaf_node
+
+       Figure 14: Derivation of Ratchet Tree Keys along a Direct Path
+
+   After applying the UpdatePath, the tree will have the following
+   structure:
+
+   node_priv[1] --------> Y'
+                          |
+                        .-+-.
+                       /     \
+   node_priv[0] ----> X'      Z[C]
+                     / \     / \
+                    A   B   C   D
+                        ^
+   leaf_priv -----------+
+                    0   1   2   3
+
+               Figure 15: Placement of Keys in a Ratchet Tree
+
+7.5.  Synchronizing Views of the Tree
+
+   After generating fresh key material and applying it to update their
+   local tree state as described in Section 7.4, the generator
+   broadcasts this update to other members of the group in a Commit
+   message, who apply it to keep their local views of the tree in sync
+   with the sender's.  More specifically, when a member commits a change
+   to the tree (e.g., to add or remove a member), it transmits an
+   UpdatePath containing a set of public keys and encrypted path secrets
+   for intermediate nodes in the filtered direct path of its leaf.  The
+   other members of the group use these values to update their view of
+   the tree, aligning their copy of the tree to the sender's.
+
+   An UpdatePath contains the following information for each node in the
+   filtered direct path of the sender's leaf, including the root:
+
+   *  The public key for the node
+
+   *  One or more encrypted copies of the path secret corresponding to
+      the node
+
+   The path secret value for a given node is encrypted to the subtree
+   rooted at the parent's non-updated child, i.e., the child on the
+   copath of the sender's leaf node.  There is one encryption of the
+   path secret to each public key in the resolution of the non-updated
+   child.
+
+   A member of the group _updates their direct path_ by computing new
+   values for their leaf node and the nodes along their filtered direct
+   path as follows:
+
+   1.  Blank all nodes along the direct path of the sender's leaf.
+
+   2.  Compute updated path secrets and public keys for the nodes on the
+       sender's filtered direct path.
+
+       *  Generate a sequence of path secrets of the same length as the
+          filtered direct path, as defined in Section 7.4.
+
+       *  For each node in the filtered direct path, replace the node's
+          public key with the node_pub[n] value derived from the
+          corresponding path secret path_secret[n].
+
+   3.  Compute the new parent hashes for the nodes along the filtered
+       direct path and the sender's leaf node.
+
+   4.  Update the leaf node for the sender.
+
+       *  Set the leaf_node_source to commit.
+
+       *  Set the encryption_key to the public key of a freshly sampled
+          key pair.
+
+       *  Set the parent hash to the parent hash for the leaf.
+
+       *  Re-sign the leaf node with its new contents.
+
+   Since the new leaf node effectively updates an existing leaf node in
+   the group, it MUST adhere to the same restrictions as LeafNodes used
+   in Update proposals (aside from leaf_node_source).  The application
+   MAY specify other changes to the leaf node, e.g., providing a new
+   signature key, updated capabilities, or different extensions.
+
+   The member then _encrypts path secrets to the group_.  For each node
+   in the member's filtered direct path, the member takes the following
+   steps:
+
+   1.  Compute the resolution of the node's child that is on the copath
+       of the sender (the child that is not in the direct path of the
+       sender).  Any new member (from an Add proposal) added in the same
+       Commit MUST be excluded from this resolution.
+
+   2.  For each node in the resolution, encrypt the path secret for the
+       direct path node using the public key of the resolution node, as
+       defined in Section 7.6.
+
+   The recipient of an UpdatePath performs the corresponding steps.
+   First, the recipient _merges UpdatePath into the tree_:
+
+   1.  Blank all nodes on the direct path of the sender's leaf.
+
+   2.  For all nodes on the filtered direct path of the sender's leaf,
+
+       *  Set the public key to the public key in the UpdatePath.
+
+       *  Set the list of unmerged leaves to the empty list.
+
+   3.  Compute parent hashes for the nodes in the sender's filtered
+       direct path, and verify that the parent_hash field of the leaf
+       node matches the parent hash for the first node in its filtered
+       direct path.
+
+       *  Note that these hashes are computed from root to leaf, so that
+          each hash incorporates all the non-blank nodes above it.  The
+          root node always has a zero-length hash for its parent hash.
+
+   Second, the recipient _decrypts the path secrets_:
+
+   1.  Identify a node in the filtered direct path for which the
+       recipient is in the subtree of the non-updated child.
+
+   2.  Identify a node in the resolution of the copath node for which
+       the recipient has a private key.
+
+   3.  Decrypt the path secret for the parent of the copath node using
+       the private key from the resolution node.
+
+   4.  Derive path secrets for ancestors of that node in the sender's
+       filtered direct path using the algorithm described above.
+
+   5.  Derive the node secrets and node key pairs from the path secrets.
+
+   6.  Verify that the derived public keys are the same as the
+       corresponding public keys sent in the UpdatePath.
+
+   7.  Store the derived private keys in the corresponding ratchet tree
+       nodes.
+
+   For example, in order to communicate the example update described in
+   Section 7.4, the member at node B would transmit the following
+   values:
+
+   +=============+====================================================+
+   | Public Key  | Ciphertext(s)                                      |
+   +=============+====================================================+
+   | node_pub[1] | E(pk(Z), path_secret[1]), E(pk(C), path_secret[1]) |
+   +-------------+----------------------------------------------------+
+   | node_pub[0] | E(pk(A), path_secret[0])                           |
+   +-------------+----------------------------------------------------+
+
+                                 Table 3
+
+   In this table, the value node_pub[i] represents the public key
+   derived from node_secret[i], pk(X) represents the current public key
+   of node X, and E(K, S) represents the public key encryption of the
+   path secret S to the public key K (using HPKE).
+
+   A recipient at node A would decrypt E(pk(A), path_secret\[0\]) to
+   obtain path_secret\[0\], then use it to derive path_secret[1] and the
+   resulting node secrets and key pairs.  Thus, A would have the private
+   keys to nodes X' and Y', in accordance with the tree invariant.
+
+   Similarly, a recipient at node D would decrypt E(pk(Z),
+   path_secret[1]) to obtain path_secret[1], then use it to derive the
+   node secret and key pair for the node Y'.  As required to maintain
+   the tree invariant, node D does not receive the private key for the
+   node X', since X' is not an ancestor of D.
+
+   After processing the update, each recipient MUST delete outdated key
+   material, specifically:
+
+   *  The path secrets and node secrets used to derive each updated node
+      key pair.
+
+   *  Each outdated node key pair that was replaced by the update.
+
+7.6.  Update Paths
+
+   As described in Section 12.4, each Commit message may optionally
+   contain an UpdatePath, with a new LeafNode and set of parent nodes
+   for the sender's filtered direct path.  For each parent node, the
+   UpdatePath contains a new public key and encrypted path secret.  The
+   parent nodes are kept in the same order as the filtered direct path.
+
+   struct {
+       opaque kem_output<V>;
+       opaque ciphertext<V>;
+   } HPKECiphertext;
+
+   struct {
+       HPKEPublicKey encryption_key;
+       HPKECiphertext encrypted_path_secret<V>;
+   } UpdatePathNode;
+
+   struct {
+       LeafNode leaf_node;
+       UpdatePathNode nodes<V>;
+   } UpdatePath;
+
+   For each UpdatePathNode, the resolution of the corresponding copath
+   node MUST exclude all new leaf nodes added as part of the current
+   Commit.  The length of the encrypted_path_secret vector MUST be equal
+   to the length of the resolution of the copath node (excluding new
+   leaf nodes), with each ciphertext being the encryption to the
+   respective resolution node.
+
+   The HPKECiphertext values are encrypted and decrypted as follows:
+
+   (kem_output, ciphertext) =
+     EncryptWithLabel(node_public_key, "UpdatePathNode",
+                      group_context, path_secret)
+
+   path_secret =
+     DecryptWithLabel(node_private_key, "UpdatePathNode",
+                      group_context, kem_output, ciphertext)
+
+   Here node_public_key is the public key of the node for which the path
+   secret is encrypted, group_context is the provisional GroupContext
+   object for the group, and the EncryptWithLabel function is as defined
+   in Section 5.1.3.
+
+7.7.  Adding and Removing Leaves
+
+   In addition to the path-based updates to the tree described above, it
+   is also necessary to add and remove leaves of the tree in order to
+   reflect changes to the membership of the group (see Sections 12.1.1
+   and 12.1.3).  Since the tree is always full, adding or removing
+   leaves corresponds to increasing or decreasing the depth of the tree,
+   resulting in the number of leaves being doubled or halved.  These
+   operations are also known as _extending_ and _truncating_ the tree.
+
+   Leaves are always added and removed at the right edge of the tree.
+   When the size of the tree needs to be increased, a new blank root
+   node is added, whose left subtree is the existing tree and right
+   subtree is a new all-blank subtree.  This operation is typically done
+   when adding a member to the group.
+
+                     _ <-- new blank root                    _
+                   __|__                                   __|__
+                  /     \                                 /     \
+     X    ===>   X       _ <-- new blank subtree ===>    X       _
+    / \         / \     / \                             / \     / \
+   A   B       A   B   _   _                           A   B   C   _
+                                                               ^
+                                                               |
+                                                  new member --+
+
+       Figure 16: Extending the Tree to Make Room for a Third Member
+
+   When the right subtree of the tree no longer has any non-blank nodes,
+   it can be safely removed.  The root of the tree and the right subtree
+   are discarded (whether or not the root node is blank).  The left
+   child of the root becomes the new root node, and the left subtree
+   becomes the new tree.  This operation is typically done after
+   removing a member from the group.
+
+                  Y                  Y
+                __|__              __|__
+               /     \            /     \
+              X       _   ===>   X       _   ==>   X <-- new root
+             / \     / \        / \     / \       / \
+            A   B   C   _      A   B   _   _     A   B
+                    ^
+                    |
+   removed member --+
+
+               Figure 17: Cleaning Up after Removing Member C
+
+   Concrete algorithms for these operations on array-based and link-
+   based trees are provided in Appendices C and D.  The concrete
+   algorithms are non-normative.  An implementation may use any
+   algorithm that produces the correct tree in its internal
+   representation.
+
+7.8.  Tree Hashes
+
+   MLS hashes the contents of the tree in two ways to authenticate
+   different properties of the tree.  _Tree hashes_ are defined in this
+   section, and _parent hashes_ are defined in Section 7.9.
+
+   Each node in a ratchet tree has a tree hash that summarizes the
+   subtree below that node.  The tree hash of the root is used in the
+   GroupContext to confirm that the group agrees on the whole tree.
+   Tree hashes are computed recursively from the leaves up to the root.
+
+   P --> th(P)
+         ^ ^
+        /   \
+       /     \
+   th(L)     th(R)
+
+                  Figure 18: Composition of the Tree Hash
+
+   The tree hash of an individual node is the hash of the node's
+   TreeHashInput object, which may contain either a LeafNodeHashInput or
+   a ParentNodeHashInput depending on the type of node.
+   LeafNodeHashInput objects contain the leaf_index and the LeafNode (if
+   any).  ParentNodeHashInput objects contain the ParentNode (if any)
+   and the tree hash of the node's left and right children.  For both
+   parent and leaf nodes, the optional node value MUST be absent if the
+   node is blank and present if the node contains a value.
+
+   enum {
+       reserved(0),
+       leaf(1),
+       parent(2),
+       (255)
+   } NodeType;
+
+   struct {
+     NodeType node_type;
+     select (TreeHashInput.node_type) {
+       case leaf:   LeafNodeHashInput leaf_node;
+       case parent: ParentNodeHashInput parent_node;
+     };
+   } TreeHashInput;
+
+   struct {
+       uint32 leaf_index;
+       optional<LeafNode> leaf_node;
+   } LeafNodeHashInput;
+
+   struct {
+       optional<ParentNode> parent_node;
+       opaque left_hash<V>;
+       opaque right_hash<V>;
+   } ParentNodeHashInput;
+
+   The tree hash of an entire tree corresponds to the tree hash of the
+   root node, which is computed recursively by starting at the leaf
+   nodes and building up.
+
+7.9.  Parent Hashes
+
+   While tree hashes summarize the state of a tree at point in time,
+   parent hashes capture information about how keys in the tree were
+   populated.
+
+   When a client sends a Commit to change a group, it can include an
+   UpdatePath to assign new keys to the nodes along its filtered direct
+   path.  When a client computes an UpdatePath (as defined in
+   Section 7.5), it computes and signs a parent hash that summarizes the
+   state of the tree after the UpdatePath has been applied.  These
+   summaries are constructed in a chain from the root to the member's
+   leaf so that the part of the chain closer to the root can be
+   overwritten as nodes set in one UpdatePath are reset by a later
+   UpdatePath.
+
+                        ph(Q)
+                        /
+                       /
+                      V
+   P.public_key --> ph(P)
+                    / ^
+                   /   \
+                  V     \
+      N.parent_hash     th(S)
+
+                     Figure 19: Inputs to a Parent Hash
+
+   As a result, the signature over the parent hash in each member's leaf
+   effectively signs the subtree of the tree that hasn't been changed
+   since that leaf was last changed in an UpdatePath.  A new member
+   joining the group uses these parent hashes to verify that the parent
+   nodes in the tree were set by members of the group, not chosen by an
+   external attacker.  For an example of how this works, see Appendix B.
+
+   Consider a ratchet tree with a non-blank parent node P and children D
+   and S (for "parent", "direct path", and "sibling"), with D and P in
+   the direct path of a leaf node L (for "leaf"):
+
+            ...
+            /
+           P
+         __|__
+        /     \
+       D       S
+      / \     / \
+    ... ... ... ...
+    /
+   L
+
+           Figure 20: Nodes Involved in a Parent Hash Computation
+
+   The parent hash of P changes whenever an UpdatePath object is applied
+   to the ratchet tree along a path from a leaf L traversing node D (and
+   hence also P).  The new "Parent hash of P (with copath child S)" is
+   obtained by hashing P's ParentHashInput struct.
+
+   struct {
+       HPKEPublicKey encryption_key;
+       opaque parent_hash<V>;
+       opaque original_sibling_tree_hash<V>;
+   } ParentHashInput;
+
+   The field encryption_key contains the HPKE public key of P.  If P is
+   the root, then the parent_hash field is set to a zero-length octet
+   string.  Otherwise, parent_hash is the parent hash of the next node
+   after P on the filtered direct path of the leaf L.  This way, P's
+   parent hash fixes the new HPKE public key of each non-blank node on
+   the path from P to the root.  Note that the path from P to the root
+   may contain some blank nodes that are not fixed by P's parent hash.
+   However, for each node that has an HPKE key, this key is fixed by P's
+   parent hash.
+
+   Finally, original_sibling_tree_hash is the tree hash of S in the
+   ratchet tree modified as follows: For each leaf L in
+   P.unmerged_leaves, blank L and remove it from the unmerged_leaves
+   sets of all parent nodes.
+
+   Observe that original_sibling_tree_hash does not change between
+   updates of P.  This property is crucial for the correctness of the
+   protocol.
+
+   Note that original_sibling_tree_hash is the tree hash of S, not the
+   parent hash.  The parent_hash field in ParentHashInput captures
+   information about the nodes above P. the original_sibling_tree_hash
+   captures information about the subtree under S that is not being
+   updated (and thus the subtree to which a path secret for P would be
+   encrypted according to Section 7.5).
+
+   For example, in the following tree:
+
+                 W [F]
+           ______|_____
+          /             \
+         U               Y [F]
+       __|__           __|__
+      /     \         /     \
+     T       _       _       _
+    / \     / \     / \     / \
+   A   B   C   D   E   F   G   _
+
+          Figure 21: A Tree Illustrating Parent Hash Computations
+
+   With P = W and S = Y, original_sibling_tree_hash is the tree hash of
+   the following tree:
+
+         Y
+       __|__
+      /     \
+     _       _
+    / \     / \
+   E   _   G   _
+
+   Because W.unmerged_leaves includes F, F is blanked and removed from
+   Y.unmerged_leaves.
+
+   Note that no recomputation is needed if the tree hash of S is
+   unchanged since the last time P was updated.  This is the case for
+   computing or processing a Commit whose UpdatePath traverses P, since
+   the Commit itself resets P.  (In other words, it is only necessary to
+   recompute the original sibling tree hash when validating a group's
+   tree on joining.)  More generally, if none of the entries in
+   P.unmerged_leaves are in the subtree under S (and thus no leaves were
+   blanked), then the original tree hash at S is the tree hash of S in
+   the current tree.
+
+   If it is necessary to recompute the original tree hash of a node, the
+   efficiency of recomputation can be improved by caching intermediate
+   tree hashes, to avoid recomputing over the subtree when the subtree
+   is included in multiple parent hashes.  A subtree hash can be reused
+   as long as the intersection of the parent's unmerged leaves with the
+   subtree is the same as in the earlier computation.
+
+7.9.1.  Using Parent Hashes
+
+   In ParentNode objects and LeafNode objects with leaf_node_source set
+   to commit, the value of the parent_hash field is the parent hash of
+   the next non-blank parent node above the node in question (the next
+   node in the filtered direct path).  Using the node labels in
+   Figure 20, the parent_hash field of D is equal to the parent hash of
+   P with copath child S.  This is the case even when the node D is a
+   leaf node.
+
+   The parent_hash field of a LeafNode is signed by the member.  The
+   signature of such a LeafNode thus attests to which keys the group
+   member introduced into the ratchet tree and to whom the corresponding
+   secret keys were sent, in addition to the other contents of the
+   LeafNode.  This prevents malicious insiders from constructing
+   artificial ratchet trees with a node D whose HPKE secret key is known
+   to the insider, yet where the insider isn't assigned a leaf in the
+   subtree rooted at D.  Indeed, such a ratchet tree would violate the
+   tree invariant.
+
+7.9.2.  Verifying Parent Hashes
+
+   Parent hashes are verified at two points in the protocol: When
+   joining a group and when processing a Commit.
+
+   The parent hash in a node D is valid with respect to a parent node P
+   if the following criteria hold.  Here C and S are the children of P
+   (for "child" and "sibling"), with C being the child that is on the
+   direct path of D (possibly D itself) and S being the other child:
+
+   *  D is a descendant of P in the tree.
+
+   *  The parent_hash field of D is equal to the parent hash of P with
+      copath child S.
+
+   *  D is in the resolution of C, and the intersection of P's
+      unmerged_leaves with the subtree under C is equal to the
+      resolution of C with D removed.
+
+   These checks verify that D and P were updated at the same time (in
+   the same UpdatePath), and that they were neighbors in the UpdatePath
+   because the nodes in between them would have omitted from the
+   filtered direct path.
+
+   A parent node P is "parent-hash valid" if it can be chained back to a
+   leaf node in this way.  That is, if there is leaf node L and a
+   sequence of parent nodes P_1, ..., P_N such that P_N = P and each
+   step in the chain is authenticated by a parent hash, then L's parent
+   hash is valid with respect to P_1, P_1's parent hash is valid with
+   respect to P_2, and so on.
+
+   When joining a group, the new member MUST authenticate that each non-
+   blank parent node P is parent-hash valid.  This can be done "bottom
+   up" by building chains up from leaves and verifying that all non-
+   blank parent nodes are covered by exactly one such chain, or "top
+   down" by verifying that there is exactly one descendant of each non-
+   blank parent node for which the parent node is parent-hash valid.
+
+   When processing a Commit message that includes an UpdatePath, clients
+   MUST recompute the expected value of parent_hash for the committer's
+   new leaf and verify that it matches the parent_hash value in the
+   supplied leaf_node.  After being merged into the tree, the nodes in
+   the UpdatePath form a parent-hash chain from the committer's leaf to
+   the root.
+
+8.  Key Schedule
+
+   Group keys are derived using the Extract and Expand functions from
+   the KDF for the group's cipher suite, as well as the functions
+   defined below:
+
+   ExpandWithLabel(Secret, Label, Context, Length) =
+       KDF.Expand(Secret, KDFLabel, Length)
+
+   DeriveSecret(Secret, Label) =
+       ExpandWithLabel(Secret, Label, "", KDF.Nh)
+
+   Where KDFLabel is specified as:
+
+   struct {
+       uint16 length;
+       opaque label<V>;
+       opaque context<V>;
+   } KDFLabel;
+
+   And its fields are set to:
+
+   length = Length;
+   label = "MLS 1.0 " + Label;
+   context = Context;
+
+   The value KDF.Nh is the size of an output from KDF.Extract, in bytes.
+   In the below diagram:
+
+   *  KDF.Extract takes its salt argument from the top and its Input
+      Keying Material (IKM) argument from the left.
+
+   *  DeriveSecret takes its Secret argument from the incoming arrow.
+
+   *  0 represents an all-zero byte string of length KDF.Nh.
+
+   When processing a handshake message, a client combines the following
+   information to derive new epoch secrets:
+
+   *  The init secret from the previous epoch
+
+   *  The commit secret for the current epoch
+
+   *  The GroupContext object for current epoch
+
+   Given these inputs, the derivation of secrets for an epoch proceeds
+   as shown in the following diagram:
+
+                    init_secret_[n-1]
+                          |
+                          |
+                          V
+    commit_secret --> KDF.Extract
+                          |
+                          |
+                          V
+                  ExpandWithLabel(., "joiner", GroupContext_[n], KDF.Nh)
+                          |
+                          |
+                          V
+                     joiner_secret
+                          |
+                          |
+                          V
+psk_secret (or 0) --> KDF.Extract
+                          |
+                          |
+                          +--> DeriveSecret(., "welcome")
+                          |    = welcome_secret
+                          |
+                          V
+                  ExpandWithLabel(., "epoch", GroupContext_[n], KDF.Nh)
+                          |
+                          |
+                          V
+                     epoch_secret
+                          |
+                          |
+                          +--> DeriveSecret(., <label>)
+                          |    = <secret>
+                          |
+                          V
+                    DeriveSecret(., "init")
+                          |
+                          |
+                          V
+                    init_secret_[n]
+
+                   Figure 22: The MLS Key Schedule
+
+   A number of values are derived from the epoch secret for different
+   purposes:
+
+    +==================+=====================+=======================+
+    | Label            | Secret              | Purpose               |
+    +==================+=====================+=======================+
+    | "sender data"    | sender_data_secret  | Deriving keys to      |
+    |                  |                     | encrypt sender data   |
+    +------------------+---------------------+-----------------------+
+    | "encryption"     | encryption_secret   | Deriving message      |
+    |                  |                     | encryption keys (via  |
+    |                  |                     | the secret tree)      |
+    +------------------+---------------------+-----------------------+
+    | "exporter"       | exporter_secret     | Deriving exported     |
+    |                  |                     | secrets               |
+    +------------------+---------------------+-----------------------+
+    | "external"       | external_secret     | Deriving the external |
+    |                  |                     | init key              |
+    +------------------+---------------------+-----------------------+
+    | "confirm"        | confirmation_key    | Computing the         |
+    |                  |                     | confirmation MAC for  |
+    |                  |                     | an epoch              |
+    +------------------+---------------------+-----------------------+
+    | "membership"     | membership_key      | Computing the         |
+    |                  |                     | membership MAC for a  |
+    |                  |                     | PublicMessage         |
+    +------------------+---------------------+-----------------------+
+    | "resumption"     | resumption_psk      | Proving membership in |
+    |                  |                     | this epoch (via a PSK |
+    |                  |                     | injected later)       |
+    +------------------+---------------------+-----------------------+
+    | "authentication" | epoch_authenticator | Confirming that two   |
+    |                  |                     | clients have the same |
+    |                  |                     | view of the group     |
+    +------------------+---------------------+-----------------------+
+
+                      Table 4: Epoch-Derived Secrets
+
+   The external_secret is used to derive an HPKE key pair whose private
+   key is held by the entire group:
+
+   external_priv, external_pub = KEM.DeriveKeyPair(external_secret)
+
+   The public key external_pub can be published as part of the GroupInfo
+   struct in order to allow non-members to join the group using an
+   external Commit.
+
+8.1.  Group Context
+
+   Each member of the group maintains a GroupContext object that
+   summarizes the state of the group:
+
+   struct {
+       ProtocolVersion version = mls10;
+       CipherSuite cipher_suite;
+       opaque group_id<V>;
+       uint64 epoch;
+       opaque tree_hash<V>;
+       opaque confirmed_transcript_hash<V>;
+       Extension extensions<V>;
+   } GroupContext;
+
+   The fields in this state have the following semantics:
+
+   *  The cipher_suite is the cipher suite used by the group.
+
+   *  The group_id field is an application-defined identifier for the
+      group.
+
+   *  The epoch field represents the current version of the group.
+
+   *  The tree_hash field contains a commitment to the contents of the
+      group's ratchet tree and the credentials for the members of the
+      group, as described in Section 7.8.
+
+   *  The confirmed_transcript_hash field contains a running hash over
+      the messages that led to this state.
+
+   *  The extensions field contains the details of any protocol
+      extensions that apply to the group.
+
+   When a new member is added to the group, an existing member of the
+   group provides the new member with a Welcome message.  The Welcome
+   message provides the information the new member needs to initialize
+   its GroupContext.
+
+   Different changes to the group will have different effects on the
+   group state.  These effects are described in their respective
+   subsections of Section 12.1.  The following general rules apply:
+
+   *  The group_id field is constant.
+
+   *  The epoch field increments by one for each Commit message that is
+      processed.
+
+   *  The tree_hash is updated to represent the current tree and
+      credentials.
+
+   *  The confirmed_transcript_hash field is updated with the data for
+      an AuthenticatedContent encoding a Commit message, as described
+      below.
+
+   *  The extensions field changes when a GroupContextExtensions
+      proposal is committed.
+
+8.2.  Transcript Hashes
+
+   The transcript hashes computed in MLS represent a running hash over
+   all Proposal and Commit messages that have ever been sent in a group.
+   Commit messages are included directly.  Proposal messages are
+   indirectly included via the Commit that applied them.  Messages of
+   both types are included by hashing the AuthenticatedContent object in
+   which they were sent.
+
+   The transcript hash comprises two individual hashes:
+
+   *  A confirmed_transcript_hash that represents a transcript over the
+      whole history of Commit messages, up to and including the
+      signature of the most recent Commit.
+
+   *  An interim_transcript_hash that covers the confirmed transcript
+      hash plus the confirmation_tag of the most recent Commit.
+
+   New members compute the interim transcript hash using the
+   confirmation_tag field of the GroupInfo struct, while existing
+   members can compute it directly.
+
+   Each Commit message updates these hashes by way of its enclosing
+   AuthenticatedContent.  The AuthenticatedContent struct is split into
+   ConfirmedTranscriptHashInput and InterimTranscriptHashInput.  The
+   former is used to update the confirmed transcript hash and the latter
+   is used to update the interim transcript hash.
+
+   struct {
+       WireFormat wire_format;
+       FramedContent content; /* with content_type == commit */
+       opaque signature<V>;
+   } ConfirmedTranscriptHashInput;
+
+   struct {
+       MAC confirmation_tag;
+   } InterimTranscriptHashInput;
+
+   confirmed_transcript_hash_[0] = ""; /* zero-length octet string */
+   interim_transcript_hash_[0] = ""; /* zero-length octet string */
+
+   confirmed_transcript_hash_[epoch] =
+       Hash(interim_transcript_hash_[epoch - 1] ||
+           ConfirmedTranscriptHashInput_[epoch]);
+
+   interim_transcript_hash_[epoch] =
+       Hash(confirmed_transcript_hash_[epoch] ||
+           InterimTranscriptHashInput_[epoch]);
+
+   In this notation, ConfirmedTranscriptHashInput_[epoch] and
+   InterimTranscriptHashInput_[epoch] are based on the Commit that
+   initiated the epoch with epoch number epoch.  (Note that
+   theepochfield in this Commit will be set toepoch - 1`, since it is
+   sent within the previous epoch.)
+
+   The transcript hash ConfirmedTranscriptHashInput_[epoch] is used as
+   the confirmed_transcript_hash input to the confirmation_tag field for
+   this Commit.  Each Commit thus confirms the whole transcript of
+   Commits up to that point, except for the latest Commit's confirmation
+   tag.
+
+                                                             ...
+
+                                                              |
+                                                              |
+                                                              V
+                                                     +-----------------+
+                                                     |  interim_[N-1]  |
+                                                     +--------+--------+
+                                                              |
+     .--------------.         +------------------+            |
+    |  Ratchet Tree  |        | wire_format      |            |
+    |  Key Schedule  |<-------+ content          |            |
+     '-------+------'         |   epoch = N-1    +------------+
+             |                |   commit         |            |
+             V                | signature        |            V
+ +------------------------+   +------------------+   +-----------------+
+ |  confirmation_key_[N]  +-->| confirmation_tag |<--+  confirmed_[N]  |
+ +------------------------+   +--------+---------+   +--------+--------+
+                                       |                      |
+                                       |                      V
+                                       |             +-----------------+
+                                       +------------>|   interim_[N]   |
+                                                     +--------+--------+
+                                                              |
+     .--------------.         +------------------+            |
+    |  Ratchet Tree  |        | wire_format      |            |
+    |  Key Schedule  |<-------+ content          |            |
+     '-------+------'         |   epoch = N      +------------+
+             |                |   commit         |            |
+             V                | signature        |            V
+ +------------------------+   +------------------+   +-----------------+
+ | confirmation_key_[N+1] +-->| confirmation_tag |<--+ confirmed_[N+1] |
+ +------------------------+   +--------+---------+   +--------+--------+
+                                       |                      |
+                                       |                      V
+                                       |             +-----------------+
+                                       +------------>|  interim_[N+1]  |
+                                                     +--------+--------+
+                                                              |
+                                                              V
+
+                                                             ...
+
+   Figure 23: Evolution of the Transcript Hashes through Two Epoch
+                               Changes
+
+8.3.  External Initialization
+
+   In addition to initializing a new epoch via KDF invocations as
+   described above, an MLS group can also initialize a new epoch via an
+   asymmetric interaction using the external key pair for the previous
+   epoch.  This is done when a new member is joining via an external
+   commit.
+
+   In this process, the joiner sends a new init_secret value to the
+   group using the HPKE export method.  The joiner then uses that
+   init_secret with information provided in the GroupInfo and an
+   external Commit to initialize their copy of the key schedule for the
+   new epoch.
+
+   kem_output, context = SetupBaseS(external_pub, "")
+   init_secret = context.export("MLS 1.0 external init secret", KDF.Nh)
+
+   Members of the group receive the kem_output in an ExternalInit
+   proposal and perform the corresponding calculation to retrieve the
+   init_secret value.
+
+   context = SetupBaseR(kem_output, external_priv, "")
+   init_secret = context.export("MLS 1.0 external init secret", KDF.Nh)
+
+8.4.  Pre-Shared Keys
+
+   Groups that already have an out-of-band mechanism to generate shared
+   group secrets can inject them into the MLS key schedule to
+   incorporate this external entropy in the computation of MLS group
+   secrets.
+
+   Injecting an external PSK can improve security in the case where
+   having a full run of Updates across members is too expensive, or if
+   the external group key establishment mechanism provides stronger
+   security against classical or quantum adversaries.
+
+   Note that, as a PSK may have a different lifetime than an Update, it
+   does not necessarily provide the same forward secrecy or post-
+   compromise security guarantees as a Commit message.  Unlike the key
+   pairs populated in the tree by an Update or Commit, which are always
+   freshly generated, PSKs may be pre-distributed and stored.  This
+   creates the risk that a PSK may be compromised in the process of
+   distribution and storage.  The security that the group gets from
+   injecting a PSK thus depends on both the entropy of the PSK and the
+   risk of compromise.  These factors are outside of the scope of this
+   document, but they should be considered by application designers
+   relying on PSKs.
+
+   Each PSK in MLS has a type that designates how it was provisioned.
+   External PSKs are provided by the application, while resumption PSKs
+   are derived from the MLS key schedule and used in cases where it is
+   necessary to authenticate a member's participation in a prior epoch.
+
+   The injection of one or more PSKs into the key schedule is signaled
+   in two ways: Existing members are informed via PreSharedKey proposals
+   covered by a Commit, and new members added in the Commit are informed
+   by the GroupSecrets object in the Welcome message corresponding to
+   the Commit.  To ensure that existing and new members compute the same
+   PSK input to the key schedule, the Commit and GroupSecrets objects
+   MUST indicate the same set of PSKs, in the same order.
+
+   enum {
+     reserved(0),
+     external(1),
+     resumption(2),
+     (255)
+   } PSKType;
+
+   enum {
+     reserved(0),
+     application(1),
+     reinit(2),
+     branch(3),
+     (255)
+   } ResumptionPSKUsage;
+
+   struct {
+     PSKType psktype;
+     select (PreSharedKeyID.psktype) {
+       case external:
+         opaque psk_id<V>;
+
+       case resumption:
+         ResumptionPSKUsage usage;
+         opaque psk_group_id<V>;
+         uint64 psk_epoch;
+     };
+     opaque psk_nonce<V>;
+   } PreSharedKeyID;
+
+   Each time a client injects a PSK into a group, the psk_nonce of its
+   PreSharedKeyID MUST be set to a fresh random value of length KDF.Nh,
+   where KDF is the KDF for the cipher suite of the group into which the
+   PSK is being injected.  This ensures that even when a PSK is used
+   multiple times, the value used as an input into the key schedule is
+   different each time.
+
+   Upon receiving a Commit with a PreSharedKey proposal or a
+   GroupSecrets object with the psks field set, the receiving client
+   includes them in the key schedule in the order listed in the Commit,
+   or in the psks field, respectively.  For resumption PSKs, the PSK is
+   defined as the resumption_psk of the group and epoch specified in the
+   PreSharedKeyID object.  Specifically, psk_secret is computed as
+   follows:
+
+   struct {
+       PreSharedKeyID id;
+       uint16 index;
+       uint16 count;
+   } PSKLabel;
+
+   psk_extracted_[i] = KDF.Extract(0, psk_[i])
+   psk_input_[i] = ExpandWithLabel(psk_extracted_[i], "derived psk",
+                     PSKLabel, KDF.Nh)
+
+   psk_secret_[0] = 0
+   psk_secret_[i] = KDF.Extract(psk_input_[i-1], psk_secret_[i-1])
+   psk_secret     = psk_secret_[n]
+
+   Here 0 represents the all-zero vector of length KDF.Nh.  The index
+   field in PSKLabel corresponds to the index of the PSK in the psk
+   array, while the count field contains the total number of PSKs.  In
+   other words, the PSKs are chained together with KDF.Extract
+   invocations (labeled "Extract" for brevity in the diagram), as
+   follows:
+
+                   0                               0    = psk_secret_[0]
+                   |                               |
+                   V                               V
+  psk_[0]   --> Extract --> ExpandWithLabel --> Extract = psk_secret_[1]
+                                                   |
+                   0                               |
+                   |                               |
+                   V                               V
+  psk_[1]   --> Extract --> ExpandWithLabel --> Extract = psk_secret_[2]
+                                                   |
+                   0                              ...
+                   |                               |
+                   V                               V
+  psk_[n-1] --> Extract --> ExpandWithLabel --> Extract = psk_secret_[n]
+
+        Figure 24: Computation of a PSK Secret from a Set of PSKs
+
+   In particular, if there are no PreSharedKey proposals in a given
+   Commit, then the resulting psk_secret is psk_secret_[0], the all-zero
+   vector.
+
+8.5.  Exporters
+
+   The main MLS key schedule provides an exporter_secret that can be
+   used by an application to derive new secrets for use outside of MLS.
+
+   MLS-Exporter(Label, Context, Length) =
+          ExpandWithLabel(DeriveSecret(exporter_secret, Label),
+                            "exported", Hash(Context), Length)
+
+   Applications SHOULD provide a unique label to MLS-Exporter that
+   identifies the secret's intended purpose.  This is to help prevent
+   the same secret from being generated and used in two different
+   places.  To help avoid the same label being used in different
+   applications, an IANA registry for these labels has been defined in
+   Section 17.8.
+
+   The exported values are bound to the group epoch from which the
+   exporter_secret is derived, and hence reflect a particular state of
+   the group.
+
+   It is RECOMMENDED for the application generating exported values to
+   refresh those values after a Commit is processed.
+
+8.6.  Resumption PSK
+
+   The main MLS key schedule provides a resumption_psk that is used as a
+   PSK to inject entropy from one epoch into another.  This
+   functionality is used in the reinitialization and branching processes
+   described in Sections 11.2 and 11.3, but it may be used by
+   applications for other purposes.
+
+   Some uses of resumption PSKs might call for the use of PSKs from
+   historical epochs.  The application SHOULD specify an upper limit on
+   the number of past epochs for which the resumption_psk may be stored.
+
+8.7.  Epoch Authenticators
+
+   The main MLS key schedule provides a per-epoch epoch_authenticator.
+   If one member of the group is being impersonated by an active
+   attacker, the epoch_authenticator computed by their client will
+   differ from those computed by the other group members.
+
+   This property can be used to construct defenses against impersonation
+   attacks that are effective even if members' signature keys are
+   compromised.  As a trivial example, if the users of the clients in an
+   MLS group were to meet in person and reliably confirm that their
+   epoch authenticator values were equal (using some suitable user
+   interface), then each user would be assured that the others were not
+   being impersonated in the current epoch.  As soon as the epoch
+   changed, though, they would need to redo this confirmation.  The
+   state of the group would have changed, possibly introducing an
+   attacker.
+
+   More generally, in order for the members of an MLS group to obtain
+   concrete authentication protections using the epoch_authenticator,
+   they will need to use it in some secondary protocol (such as the
+   face-to-face protocol above).  The details of that protocol will then
+   determine the specific authentication protections provided to the MLS
+   group.
+
+9.  Secret Tree
+
+   For the generation of encryption keys and nonces, the key schedule
+   begins with the encryption_secret at the root and derives a tree of
+   secrets with the same structure as the group's ratchet tree.  Each
+   leaf in the secret tree is associated with the same group member as
+   the corresponding leaf in the ratchet tree.
+
+   If N is a parent node in the secret tree, then the secrets of the
+   children of N are defined as follows (where left(N) and right(N)
+   denote the children of N):
+
+   tree_node_[N]_secret
+           |
+           |
+           +--> ExpandWithLabel(., "tree", "left", KDF.Nh)
+           |    = tree_node_[left(N)]_secret
+           |
+           +--> ExpandWithLabel(., "tree", "right", KDF.Nh)
+                = tree_node_[right(N)]_secret
+
+     Figure 25: Derivation of Secrets from Parent to Children within a
+                                Secret Tree
+
+   The secret in the leaf of the secret tree is used to initiate two
+   symmetric hash ratchets, from which a sequence of single-use keys and
+   nonces are derived, as described in Section 9.1.  The root of each
+   ratchet is computed as:
+
+   tree_node_[N]_secret
+           |
+           |
+           +--> ExpandWithLabel(., "handshake", "", KDF.Nh)
+           |    = handshake_ratchet_secret_[N]_[0]
+           |
+           +--> ExpandWithLabel(., "application", "", KDF.Nh)
+                = application_ratchet_secret_[N]_[0]
+
+     Figure 26: Initialization of the Hash Ratchets from the Leaves of
+                               a Secret Tree
+
+9.1.  Encryption Keys
+
+   As described in Section 6, MLS encrypts three different types of
+   information:
+
+   *  Metadata (sender information)
+
+   *  Handshake messages (Proposal and Commit)
+
+   *  Application messages
+
+   The sender information used to look up the key for content encryption
+   is encrypted with an AEAD where the key and nonce are derived from
+   both sender_data_secret and a sample of the encrypted message
+   content.
+
+   For handshake and application messages, a sequence of keys is derived
+   via a "sender ratchet".  Each sender has their own sender ratchet,
+   and each step along the ratchet is called a "generation".
+
+   The following figure shows a secret tree for a four-member group,
+   with the handshake and application ratchets that member D will use
+   for sending and the first two application keys and nonces.
+
+          G
+          |
+        .-+-.
+       /     \
+      E       F
+     / \     / \
+    A   B   C   D
+               / \
+             HR0  AR0--+--K0
+                   |   |
+                   |   +--N0
+                   |
+                  AR1--+--K1
+                   |   |
+                   |   +--N1
+                   |
+                  AR2
+
+               Figure 27: Secret Tree for a Four-Member Group
+
+   A sender ratchet starts from a per-sender base secret derived from a
+   Secret Tree, as described in Section 9.  The base secret initiates a
+   symmetric hash ratchet, which generates a sequence of keys and
+   nonces.  The sender uses the j-th key/nonce pair in the sequence to
+   encrypt (using the AEAD) the j-th message they send during that
+   epoch.  Each key/nonce pair MUST NOT be used to encrypt more than one
+   message.
+
+   Keys, nonces, and the secrets in ratchets are derived using
+   DeriveTreeSecret.  The context in a given call consists of the
+   current position in the ratchet.
+
+   DeriveTreeSecret(Secret, Label, Generation, Length) =
+       ExpandWithLabel(Secret, Label, Generation, Length)
+
+   Where Generation is encoded as a big endian uint32.
+
+   ratchet_secret_[N]_[j]
+         |
+         +--> DeriveTreeSecret(., "nonce", j, AEAD.Nn)
+         |    = ratchet_nonce_[N]_[j]
+         |
+         +--> DeriveTreeSecret(., "key", j,  AEAD.Nk)
+         |    = ratchet_key_[N]_[j]
+         |
+         V
+   DeriveTreeSecret(., "secret", j, KDF.Nh)
+   = ratchet_secret_[N]_[j+1]
+
+   Here AEAD.Nn and AEAD.Nk denote the lengths in bytes of the nonce and
+   key for the AEAD scheme defined by the cipher suite.
+
+9.2.  Deletion Schedule
+
+   It is important to delete all security-sensitive values as soon as
+   they are _consumed_. A sensitive value S is said to be _consumed_ if:
+
+   *  S was used to encrypt or (successfully) decrypt a message, or
+
+   *  a key, nonce, or secret derived from S has been consumed.  (This
+      goes for values derived via DeriveSecret as well as
+      ExpandWithLabel.)
+
+   Here S may be the init_secret, commit_secret, epoch_secret, or
+   encryption_secret as well as any secret in a secret tree or one of
+   the ratchets.
+
+   As soon as a group member consumes a value, they MUST immediately
+   delete (all representations of) that value.  This is crucial to
+   ensuring forward secrecy for past messages.  Members MAY keep
+   unconsumed values around for some reasonable amount of time to handle
+   out-of-order message delivery.
+
+   For example, suppose a group member encrypts or (successfully)
+   decrypts an application message using the j-th key and nonce in the
+   ratchet of leaf node L in some epoch n.  Then, for that member, at
+   least the following values have been consumed and MUST be deleted:
+
+   *  the commit_secret, joiner_secret, epoch_secret, and
+      encryption_secret of that epoch n as well as the init_secret of
+      the previous epoch n-1,
+
+   *  all node secrets in the secret tree on the path from the root to
+      the leaf with node L,
+
+   *  the first j secrets in the application data ratchet of node L, and
+
+   *  application_ratchet_nonce_[L]_[j] and
+      application_ratchet_key_[L]_[j].
+
+   Concretely, consider the secret tree shown in Figure 27.  Client A,
+   B, or C would generate the illustrated values on receiving a message
+   from D with generation equal to 1, having not received a message with
+   generation 0 (e.g., due to out-of-order delivery).  In such a case,
+   the following values would be consumed:
+
+   *  The key K1 and nonce N1 used to decrypt the message
+
+   *  The application ratchet secrets AR1 and AR0
+
+   *  The tree secrets D, F, and G (recall that G is the
+      encryption_secret for the epoch)
+
+   *  The epoch_secret, commit_secret, psk_secret, and joiner_secret for
+      the current epoch
+
+   Other values may be retained (not consumed):
+
+   *  K0 and N0 for decryption of an out-of-order message with
+      generation 0
+
+   *  AR2 for derivation of further message decryption keys and nonces
+
+   *  HR0 for protection of handshake messages from D
+
+   *  E and C for deriving secrets used by senders A, B, and C
+
+10.  Key Packages
+
+   In order to facilitate the asynchronous addition of clients to a
+   group, clients can pre-publish KeyPackage objects that provide some
+   public information about a user.  A KeyPackage object specifies:
+
+   1.  a protocol version and cipher suite that the client supports,
+
+   2.  a public key that others can use to encrypt a Welcome message to
+       this client (an "init key"), and
+
+   3.  the content of the leaf node that should be added to the tree to
+       represent this client.
+
+   KeyPackages are intended to be used only once and SHOULD NOT be
+   reused except in the case of a "last resort" KeyPackage (see
+   Section 16.8).  Clients MAY generate and publish multiple KeyPackages
+   to support multiple cipher suites.
+
+   The value for init_key MUST be a public key for the asymmetric
+   encryption scheme defined by cipher_suite, and it MUST be unique
+   among the set of KeyPackages created by this client.  Likewise, the
+   leaf_node field MUST be valid for the cipher suite, including both
+   the encryption_key and signature_key fields.  The whole structure is
+   signed using the client's signature key.  A KeyPackage object with an
+   invalid signature field MUST be considered malformed.
+
+   The signature is computed by the function SignWithLabel with a label
+   "KeyPackageTBS" and a Content input comprising all of the fields
+   except for the signature field.
+
+   struct {
+       ProtocolVersion version;
+       CipherSuite cipher_suite;
+       HPKEPublicKey init_key;
+       LeafNode leaf_node;
+       Extension extensions<V>;
+       /* SignWithLabel(., "KeyPackageTBS", KeyPackageTBS) */
+       opaque signature<V>;
+   } KeyPackage;
+
+   struct {
+       ProtocolVersion version;
+       CipherSuite cipher_suite;
+       HPKEPublicKey init_key;
+       LeafNode leaf_node;
+       Extension extensions<V>;
+   } KeyPackageTBS;
+
+   If a client receives a KeyPackage carried within an MLSMessage
+   object, then it MUST verify that the version field of the KeyPackage
+   has the same value as the version field of the MLSMessage.  The
+   version field in the KeyPackage provides an explicit signal of the
+   intended version to the other members of group when they receive the
+   KeyPackage in an Add proposal.
+
+   The field leaf_node.capabilities indicates what protocol versions,
+   cipher suites, credential types, and non-default proposal/extension
+   types are supported by the client.  (As discussed in Section 7.2,
+   some proposal and extension types defined in this document are
+   considered "default" and thus are not listed.)  This information
+   allows MLS session establishment to be safe from downgrade attacks on
+   the parameters described (as discussed in Section 11), while still
+   only advertising one version and one cipher suite per KeyPackage.
+
+   The field leaf_node.leaf_node_source of the LeafNode in a KeyPackage
+   MUST be set to key_package.
+
+   Extensions included in the extensions or leaf_node.extensions fields
+   MUST be included in the leaf_node.capabilities field.  As discussed
+   in Section 13, unknown extensions in KeyPackage.extensions MUST be
+   ignored, and the creator of a KeyPackage object SHOULD include some
+   random GREASE extensions to help ensure that other clients correctly
+   ignore unknown extensions.
+
+10.1.  KeyPackage Validation
+
+   The validity of a KeyPackage needs to be verified at a few stages:
+
+   *  When a KeyPackage is downloaded by a group member, before it is
+      used to add the client to the group
+
+   *  When a KeyPackage is received by a group member in an Add message
+
+   The client verifies the validity of a KeyPackage using the following
+   steps:
+
+   *  Verify that the cipher suite and protocol version of the
+      KeyPackage match those in the GroupContext.
+
+   *  Verify that the leaf_node of the KeyPackage is valid for a
+      KeyPackage according to Section 7.3.
+
+   *  Verify that the signature on the KeyPackage is valid using the
+      public key in leaf_node.credential.
+
+   *  Verify that the value of leaf_node.encryption_key is different
+      from the value of the init_key field.
+
+11.  Group Creation
+
+   A group is always created with a single member, the "creator".  Other
+   members are then added to the group using the usual Add/Commit
+   mechanism.
+
+   The creator of a group is responsible for setting the group ID,
+   cipher suite, and initial extensions for the group.  If the creator
+   intends to add other members at the time of creation, then it SHOULD
+   fetch KeyPackages for the members to be added, and select a cipher
+   suite and extensions according to the capabilities of the members.
+   To protect against downgrade attacks, the creator MUST use the
+   capabilities information in these KeyPackages to verify that the
+   chosen version and cipher suite is the best option supported by all
+   members.
+
+   Group IDs SHOULD be constructed in such a way that there is an
+   overwhelmingly low probability of honest group creators generating
+   the same group ID, even without assistance from the Delivery Service.
+   This can be done, for example, by making the group ID a freshly
+   generated random value of size KDF.Nh.  The Delivery Service MAY
+   attempt to ensure that group IDs are globally unique by rejecting the
+   creation of new groups with a previously used ID.
+
+   To initialize a group, the creator of the group MUST take the
+   following steps:
+
+   *  Initialize a one-member group with the following initial values:
+
+      -  Ratchet tree: A tree with a single node, a leaf node containing
+         an HPKE public key and credential for the creator
+
+      -  Group ID: A value set by the creator
+
+      -  Epoch: 0
+
+      -  Tree hash: The root hash of the above ratchet tree
+
+      -  Confirmed transcript hash: The zero-length octet string
+
+      -  Epoch secret: A fresh random value of size KDF.Nh
+
+      -  Extensions: Any values of the creator's choosing
+
+   *  Calculate the interim transcript hash:
+
+      -  Derive the confirmation_key for the epoch as described in
+         Section 8.
+
+      -  Compute a confirmation_tag over the empty
+         confirmed_transcript_hash using the confirmation_key as
+         described in Section 6.1.
+
+      -  Compute the updated interim_transcript_hash from the
+         confirmed_transcript_hash and the confirmation_tag as described
+         in Section 8.2.
+
+   At this point, the creator's state represents a one-member group with
+   a fully initialized key schedule, transcript hashes, etc.  Proposals
+   and Commits can be generated for this group state just like any other
+   state of the group, such as Add proposals and Commits to add other
+   members to the group.  A GroupInfo object for this group state can
+   also be published to facilitate external joins.
+
+   Members other than the creator join either by being sent a Welcome
+   message (as described in Section 12.4.3.1) or by sending an external
+   Commit (see Section 12.4.3.2).
+
+   In principle, the above process could be streamlined by having the
+   creator directly create a tree and choose a random value for first
+   epoch's epoch secret.  We follow the steps above because it removes
+   unnecessary choices, by which, for example, bad randomness could be
+   introduced.  The only choices the creator makes here are its own
+   KeyPackage and the leaf secret from which the Commit is built.
+
+11.1.  Required Capabilities
+
+   The configuration of a group imposes certain requirements on clients
+   in the group.  At a minimum, all members of the group need to support
+   the cipher suite and protocol version in use.  Additional
+   requirements can be imposed by including a required_capabilities
+   extension in the GroupContext.
+
+   struct {
+       ExtensionType extension_types<V>;
+       ProposalType proposal_types<V>;
+       CredentialType credential_types<V>;
+   } RequiredCapabilities;
+
+   This extension lists the extensions, proposals, and credential types
+   that must be supported by all members of the group.  The "default"
+   proposal and extension types defined in this document are assumed to
+   be implemented by all clients, and need not be listed in
+   RequiredCapabilities in order to be safely used.  Note that this is
+   not true for credential types.
+
+   For new members, support for required capabilities is enforced by
+   existing members during the application of Add commits.  Existing
+   members should of course be in compliance already.  In order to
+   ensure this continues to be the case even as the group's extensions
+   are updated, a GroupContextExtensions proposal is deemed invalid if
+   it contains a required_capabilities extension that requires non-
+   default capabilities not supported by all current members.
+
+11.2.  Reinitialization
+
+   A group may be reinitialized by creating a new group with the same
+   membership and different parameters, and linking it to the old group
+   via a resumption PSK.  The members of a group reinitialize it using
+   the following steps:
+
+   1.  A member of the old group sends a ReInit proposal (see
+       Section 12.1.5).
+
+   2.  A member of the old group sends a Commit covering the ReInit
+       proposal.
+
+   3.  A member of the old group creates an initial Commit that sets up
+       a new group that matches the ReInit and sends a Welcome message:
+
+       *  The version, cipher_suite, group_id, and extensions fields of
+          the GroupContext object in the Welcome message MUST be the
+          same as the corresponding fields in the ReInit proposal.  The
+          epoch in the Welcome message MUST be 1.
+
+       *  The Welcome message MUST specify a PreSharedKeyID of type
+          resumption with usage reinit, where the group_id field matches
+          the old group and the epoch field indicates the epoch after
+          the Commit covering the ReInit.
+
+   Note that these three steps may be done by the same group member or
+   different members.  For example, if a group member sends a Commit
+   with an inline ReInit proposal (steps 1 and 2) but then goes offline,
+   another group member may recreate the group instead.  This
+   flexibility avoids situations where a group gets stuck between steps
+   2 and 3.
+
+   Resumption PSKs with usage reinit MUST NOT be used in other contexts.
+   A PreSharedKey proposal with type resumption and usage reinit MUST be
+   considered invalid.
+
+11.3.  Subgroup Branching
+
+   A new group can be formed from a subset of an existing group's
+   members, using the same parameters as the old group.
+
+   A member can create a subgroup by performing the following steps:
+
+   1.  Fetch a new KeyPackage for each group member that should be
+       included in the subgroup.
+
+   2.  Create an initial Commit message that sets up the new group and
+       contains a PreSharedKey proposal of type resumption with usage
+       branch.  To avoid key reuse, the psk_nonce included in the
+       PreSharedKeyID object MUST be a randomly sampled nonce of length
+       KDF.Nh.
+
+   3.  Send the corresponding Welcome message to the subgroup members.
+
+   A client receiving a Welcome message including a PreSharedKey of type
+   resumption with usage branch MUST verify that the new group reflects
+   a subgroup branched from the referenced group by checking that:
+
+   *  The version and cipher_suite values in the Welcome message are the
+      same as those used by the old group.
+
+   *  The epoch in the Welcome message MUST be 1.
+
+   *  Each LeafNode in a new subgroup MUST match some LeafNode in the
+      original group.  In this context, a pair of LeafNodes is said to
+      "match" if the identifiers presented by their respective
+      credentials are considered equivalent by the application.
+
+   Resumption PSKs with usage branch MUST NOT be used in other contexts.
+   A PreSharedKey proposal with type resumption and usage branch MUST be
+   considered invalid.
+
+12.  Group Evolution
+
+   Over the lifetime of a group, its membership can change, and existing
+   members might want to change their keys in order to achieve post-
+   compromise security.  In MLS, each such change is accomplished by a
+   two-step process:
+
+   1.  A proposal to make the change is broadcast to the group in a
+       Proposal message.
+
+   2.  A member of the group or a new member broadcasts a Commit message
+       that causes one or more proposed changes to enter into effect.
+
+   In cases where the Proposal and Commit are sent by the same member,
+   these two steps can be combined by sending the proposals in the
+   commit.
+
+   The group thus evolves from one cryptographic state to another each
+   time a Commit message is sent and processed.  These states are
+   referred to as "epochs" and are uniquely identified among states of
+   the group by eight-octet epoch values.  When a new group is
+   initialized, its initial state epoch is 0x0000000000000000.  Each
+   time a state transition occurs, the epoch number is incremented by
+   one.
+
+12.1.  Proposals
+
+   Proposals are included in a FramedContent by way of a Proposal
+   structure that indicates their type:
+
+   // See the "MLS Proposal Types" IANA registry for values
+   uint16 ProposalType;
+
+   struct {
+       ProposalType proposal_type;
+       select (Proposal.proposal_type) {
+           case add:                      Add;
+           case update:                   Update;
+           case remove:                   Remove;
+           case psk:                      PreSharedKey;
+           case reinit:                   ReInit;
+           case external_init:            ExternalInit;
+           case group_context_extensions: GroupContextExtensions;
+       };
+   } Proposal;
+
+   On receiving a FramedContent containing a Proposal, a client MUST
+   verify the signature inside FramedContentAuthData and that the epoch
+   field of the enclosing FramedContent is equal to the epoch field of
+   the current GroupContext object.  If the verification is successful,
+   then the Proposal should be cached in such a way that it can be
+   retrieved by hash (as a ProposalOrRef object) in a later Commit
+   message.
+
+12.1.1.  Add
+
+   An Add proposal requests that a client with a specified KeyPackage be
+   added to the group.
+
+   struct {
+       KeyPackage key_package;
+   } Add;
+
+   An Add proposal is invalid if the KeyPackage is invalid according to
+   Section 10.1.
+
+   An Add is applied after being included in a Commit message.  The
+   position of the Add in the list of proposals determines the leaf node
+   where the new member will be added.  For the first Add in the Commit,
+   the corresponding new member will be placed in the leftmost empty
+   leaf in the tree, for the second Add, the next empty leaf to the
+   right, etc.  If no empty leaf exists, the tree is extended to the
+   right.
+
+   *  Identify the leaf L for the new member: if there are empty leaves
+      in the tree, L is the leftmost empty leaf.  Otherwise, the tree is
+      extended to the right as described in Section 7.7, and L is
+      assigned the leftmost new blank leaf.
+
+   *  For each non-blank intermediate node along the path from the leaf
+      L to the root, add L's leaf index to the unmerged_leaves list for
+      the node.
+
+   *  Set the leaf node L to a new node containing the LeafNode object
+      carried in the leaf_node field of the KeyPackage in the Add.
+
+12.1.2.  Update
+
+   An Update proposal is a similar mechanism to Add with the distinction
+   that it replaces the sender's LeafNode in the tree instead of adding
+   a new leaf to the tree.
+
+   struct {
+       LeafNode leaf_node;
+   } Update;
+
+   An Update proposal is invalid if the LeafNode is invalid for an
+   Update proposal according to Section 7.3.
+
+   A member of the group applies an Update message by taking the
+   following steps:
+
+   *  Replace the sender's LeafNode with the one contained in the Update
+      proposal.
+
+   *  Blank the intermediate nodes along the path from the sender's leaf
+      to the root.
+
+12.1.3.  Remove
+
+   A Remove proposal requests that the member with the leaf index
+   removed be removed from the group.
+
+   struct {
+       uint32 removed;
+   } Remove;
+
+   A Remove proposal is invalid if the removed field does not identify a
+   non-blank leaf node.
+
+   A member of the group applies a Remove message by taking the
+   following steps:
+
+   *  Identify the leaf node matching removed.  Let L be this leaf node.
+
+   *  Replace the leaf node L with a blank node.
+
+   *  Blank the intermediate nodes along the path from L to the root.
+
+   *  Truncate the tree by removing the right subtree until there is at
+      least one non-blank leaf node in the right subtree.  If the
+      rightmost non-blank leaf has index L, then this will result in the
+      tree having 2^d leaves, where d is the smallest value such that
+      2^d > L.
+
+12.1.4.  PreSharedKey
+
+   A PreSharedKey proposal can be used to request that a pre-shared key
+   be injected into the key schedule in the process of advancing the
+   epoch.
+
+   struct {
+       PreSharedKeyID psk;
+   } PreSharedKey;
+
+   A PreSharedKey proposal is invalid if any of the following is true:
+
+   *  The PreSharedKey proposal is not being processed as part of a
+      reinitialization of the group (see Section 11.2), and the
+      PreSharedKeyID has psktype set to resumption and usage set to
+      reinit.
+
+   *  The PreSharedKey proposal is not being processed as part of a
+      subgroup branching operation (see Section 11.3), and the
+      PreSharedKeyID has psktype set to resumption and usage set to
+      branch.
+
+   *  The psk_nonce is not of length KDF.Nh.
+
+   The psk_nonce MUST be randomly sampled.  When processing a Commit
+   message that includes one or more PreSharedKey proposals, group
+   members derive psk_secret as described in Section 8.4, where the
+   order of the PSKs corresponds to the order of the PreSharedKey
+   proposals in the Commit.
+
+12.1.5.  ReInit
+
+   A ReInit proposal represents a request to reinitialize the group with
+   different parameters, for example, to increase the version number or
+   to change the cipher suite.  The reinitialization is done by creating
+   a completely new group and shutting down the old one.
+
+   struct {
+       opaque group_id<V>;
+       ProtocolVersion version;
+       CipherSuite cipher_suite;
+       Extension extensions<V>;
+   } ReInit;
+
+   A ReInit proposal is invalid if the version field is less than the
+   version for the current group.
+
+   A member of the group applies a ReInit proposal by waiting for the
+   committer to send the Welcome message that matches the ReInit,
+   according to the criteria in Section 11.2.
+
+12.1.6.  ExternalInit
+
+   An ExternalInit proposal is used by new members that want to join a
+   group by using an external commit.  This proposal can only be used in
+   that context.
+
+   struct {
+     opaque kem_output<V>;
+   } ExternalInit;
+
+   A member of the group applies an ExternalInit message by initializing
+   the next epoch using an init secret computed as described in
+   Section 8.3.  The kem_output field contains the required KEM output.
+
+12.1.7.  GroupContextExtensions
+
+   A GroupContextExtensions proposal is used to update the list of
+   extensions in the GroupContext for the group.
+
+   struct {
+     Extension extensions<V>;
+   } GroupContextExtensions;
+
+   A GroupContextExtensions proposal is invalid if it includes a
+   required_capabilities extension and some members of the group do not
+   support some of the required capabilities (including those added in
+   the same Commit, and excluding those removed).
+
+   A member of the group applies a GroupContextExtensions proposal with
+   the following steps:
+
+   *  Remove all of the existing extensions from the GroupContext object
+      for the group and replace them with the list of extensions in the
+      proposal.  (This is a wholesale replacement, not a merge.  An
+      extension is only carried over if the sender of the proposal
+      includes it in the new list.)
+
+   Note that once the GroupContext is updated, its inclusion in the
+   confirmation_tag by way of the key schedule will confirm that all
+   members of the group agree on the extensions in use.
+
+12.1.8.  External Proposals
+
+   Proposals can be constructed and sent to the group by a party that is
+   outside the group in two cases.  One case, indicated by the external
+   SenderType, allows an entity outside the group to submit proposals to
+   the group.  For example, an automated service might propose removing
+   a member of a group who has been inactive for a long time, or propose
+   adding a newly hired staff member to a group representing a real-
+   world team.  An external sender might send a ReInit proposal to
+   enforce a changed policy regarding MLS versions or cipher suites.
+
+   The external SenderType requires that signers are pre-provisioned to
+   the clients within a group and can only be used if the
+   external_senders extension is present in the group's GroupContext.
+
+   The other case, indicated by the new_member_proposal SenderType, is
+   useful when existing members of the group can independently verify
+   that an Add proposal sent by the new joiner itself (not an existing
+   member) is authorized.  External proposals that are not authorized
+   are considered invalid.
+
+   An external proposal MUST be sent as a PublicMessage object, since
+   the sender will not have the keys necessary to construct a
+   PrivateMessage object.
+
+   Proposals of some types cannot be sent by an external sender.  Among
+   the proposal types defined in this document, only the following types
+   may be sent by an external sender:
+
+   *  add
+
+   *  remove
+
+   *  psk
+
+   *  reinit
+
+   *  group_context_extensions
+
+   Messages from external senders containing proposal types other than
+   the above MUST be rejected as malformed.  New proposal types defined
+   in the future MUST define whether they may be sent by external
+   senders.  The "Ext" column in the "MLS Proposal Types" registry
+   (Section 17.4) reflects this property.
+
+12.1.8.1.  External Senders Extension
+
+   The external_senders extension is a group context extension that
+   contains the credentials and signature keys of senders that are
+   permitted to send external proposals to the group.
+
+   struct {
+     SignaturePublicKey signature_key;
+     Credential credential;
+   } ExternalSender;
+
+   ExternalSender external_senders<V>;
+
+12.2.  Proposal List Validation
+
+   A group member creating a Commit and a group member processing a
+   Commit MUST verify that the list of committed proposals is valid
+   using one of the following procedures, depending on whether the
+   Commit is external or not.  If the list of proposals is invalid, then
+   the Commit message MUST be rejected as invalid.
+
+   For a regular, i.e., not external, Commit, the list is invalid if any
+   of the following occurs:
+
+   *  It contains an individual proposal that is invalid as specified in
+      Section 12.1.
+
+   *  It contains an Update proposal generated by the committer.
+
+   *  It contains a Remove proposal that removes the committer.
+
+   *  It contains multiple Update and/or Remove proposals that apply to
+      the same leaf.  If the committer has received multiple such
+      proposals they SHOULD prefer any Remove received, or the most
+      recent Update if there are no Removes.
+
+   *  It contains multiple Add proposals that contain KeyPackages that
+      represent the same client according to the application (for
+      example, identical signature keys).
+
+   *  It contains an Add proposal with a KeyPackage that represents a
+      client already in the group according to the application, unless
+      there is a Remove proposal in the list removing the matching
+      client from the group.
+
+   *  It contains multiple PreSharedKey proposals that reference the
+      same PreSharedKeyID.
+
+   *  It contains multiple GroupContextExtensions proposals.
+
+   *  It contains a ReInit proposal together with any other proposal.
+      If the committer has received other proposals during the epoch,
+      they SHOULD prefer them over the ReInit proposal, allowing the
+      ReInit to be resent and applied in a subsequent epoch.
+
+   *  It contains an ExternalInit proposal.
+
+   *  It contains a Proposal with a non-default proposal type that is
+      not supported by some members of the group that will process the
+      Commit (i.e., members being added or removed by the Commit do not
+      need to support the proposal type).
+
+   *  After processing the Commit the ratchet tree is invalid, in
+      particular, if it contains any leaf node that is invalid according
+      to Section 7.3.
+
+   An application may extend the above procedure by additional rules,
+   for example, requiring application-level permissions to add members,
+   or rules concerning non-default proposal types.
+
+   For an external Commit, the list is valid if it contains only the
+   following proposals (not necessarily in this order):
+
+   *  Exactly one ExternalInit
+
+   *  At most one Remove proposal, with which the joiner removes an old
+      version of themselves.  If a Remove proposal is present, then the
+      LeafNode in the path field of the external Commit MUST meet the
+      same criteria as would the LeafNode in an Update for the removed
+      leaf (see Section 12.1.2).  In particular, the credential in the
+      LeafNode MUST present a set of identifiers that is acceptable to
+      the application for the removed participant.
+
+   *  Zero or more PreSharedKey proposals
+
+   *  No other proposals
+
+   Proposal types defined in the future may make updates to the above
+   validation logic to incorporate considerations related to proposals
+   of the new type.
+
+12.3.  Applying a Proposal List
+
+   The sections above defining each proposal type describe how each
+   individual proposal is applied.  When creating or processing a
+   Commit, a client applies a list of proposals to the ratchet tree and
+   GroupContext.  The client MUST apply the proposals in the list in the
+   following order:
+
+   *  If there is a GroupContextExtensions proposal, replace the
+      extensions field of the GroupContext for the group with the
+      contents of the proposal.  The new extensions MUST be used when
+      evaluating other proposals in this list.  For example, if a
+      GroupContextExtensions proposal adds a required_capabilities
+      extension, then any Add proposals need to indicate support for
+      those capabilities.
+
+   *  Apply any Update proposals to the ratchet tree, in any order.
+
+   *  Apply any Remove proposals to the ratchet tree, in any order.
+
+   *  Apply any Add proposals to the ratchet tree, in the order they
+      appear in the list.
+
+   *  Look up the PSK secrets for any PreSharedKey proposals, in the
+      order they appear in the list.  These secrets are then used to
+      advance the key schedule later in Commit processing.
+
+   *  If there is an ExternalInit proposal, use it to derive the
+      init_secret for use later in Commit processing.
+
+   *  If there is a ReInit proposal, note its parameters for application
+      later in Commit processing.
+
+   Proposal types defined in the future MUST specify how the above steps
+   are to be adjusted to accommodate the application of proposals of the
+   new type.
+
+12.4.  Commit
+
+   A Commit message initiates a new epoch for the group, based on a
+   collection of Proposals.  It instructs group members to update their
+   representation of the state of the group by applying the proposals
+   and advancing the key schedule.
+
+   Each proposal covered by the Commit is included by a ProposalOrRef
+   value, which identifies the proposal to be applied by value or by
+   reference.  Commits that refer to new Proposals from the committer
+   can be included by value.  Commits for previously sent proposals from
+   anyone (including the committer) can be sent by reference.  Proposals
+   sent by reference are specified by including the hash of the
+   AuthenticatedContent object in which the proposal was sent (see
+   Section 5.2).
+
+   enum {
+     reserved(0),
+     proposal(1),
+     reference(2),
+     (255)
+   } ProposalOrRefType;
+
+   struct {
+     ProposalOrRefType type;
+     select (ProposalOrRef.type) {
+       case proposal:  Proposal proposal;
+       case reference: ProposalRef reference;
+     };
+   } ProposalOrRef;
+
+   struct {
+       ProposalOrRef proposals<V>;
+       optional<UpdatePath> path;
+   } Commit;
+
+   A group member that has observed one or more valid proposals within
+   an epoch MUST send a Commit message before sending application data.
+   This ensures, for example, that any members whose removal was
+   proposed during the epoch are actually removed before any application
+   data is transmitted.
+
+   A sender and a receiver of a Commit MUST verify that the committed
+   list of proposals is valid as specified in Section 12.2.  A list is
+   invalid if, for example, it includes an Update and a Remove for the
+   same member, or an Add when the sender does not have the application-
+   level permission to add new users.
+
+   The sender of a Commit SHOULD include all proposals that it has
+   received during the current epoch that are valid according to the
+   rules for their proposal types and according to application policy,
+   as long as this results in a valid proposal list.
+
+   Due to the asynchronous nature of proposals, receivers of a Commit
+   SHOULD NOT enforce that all valid proposals sent within the current
+   epoch are referenced by the next Commit.  In the event that a valid
+   proposal is omitted from the next Commit, and that proposal is still
+   valid in the current epoch, the sender of the proposal MAY resend it
+   after updating it to reflect the current epoch.
+
+   A member of the group MAY send a Commit that references no proposals
+   at all, which would thus have an empty proposals vector.  Such a
+   Commit resets the sender's leaf and the nodes along its direct path,
+   and provides forward secrecy and post-compromise security with regard
+   to the sender of the Commit.  An Update proposal can be regarded as a
+   "lazy" version of this operation, where only the leaf changes and
+   intermediate nodes are blanked out.
+
+   By default, the path field of a Commit MUST be populated.  The path
+   field MAY be omitted if (a) it covers at least one proposal and (b)
+   none of the proposals covered by the Commit are of "path required"
+   types.  A proposal type requires a path if it cannot change the group
+   membership in a way that requires the forward secrecy and post-
+   compromise security guarantees that an UpdatePath provides.  The only
+   proposal types defined in this document that do not require a path
+   are:
+
+   *  add
+
+   *  psk
+
+   *  reinit
+
+   New proposal types MUST state whether they require a path.  If any
+   instance of a proposal type requires a path, then the proposal type
+   requires a path.  This attribute of a proposal type is reflected in
+   the "Path Required" field of the "MLS Proposal Types" registry
+   defined in Section 17.4.
+
+   Update and Remove proposals are the clearest examples of proposals
+   that require a path.  An UpdatePath is required to evict the removed
+   member or the old appearance of the updated member.
+
+   In pseudocode, the logic for validating the path field of a Commit is
+   as follows:
+
+   pathRequiredTypes = [
+       update,
+       remove,
+       external_init,
+       group_context_extensions
+   ]
+
+   pathRequired = false
+
+   for proposal in commit.proposals:
+       pathRequired = pathRequired ||
+                      (proposal.msg_type in pathRequiredTypes)
+
+   if len(commit.proposals) == 0 || pathRequired:
+       assert(commit.path != null)
+
+   To summarize, a Commit can have three different configurations, with
+   different uses:
+
+   1.  An "empty" Commit that references no proposals, which updates the
+       committer's contribution to the group and provides PCS with
+       regard to the committer.
+
+   2.  A "partial" Commit that references proposals that do not require
+       a path, and where the path is empty.  Such a Commit doesn't
+       provide PCS with regard to the committer.
+
+   3.  A "full" Commit that references proposals of any type, which
+       provides FS with regard to any removed members and PCS for the
+       committer and any updated members.
+
+12.4.1.  Creating a Commit
+
+   When creating or processing a Commit, a client updates the ratchet
+   tree and GroupContext for the group.  These values advance from an
+   "old" state reflecting the current epoch to a "new" state reflecting
+   the new epoch initiated by the Commit.  When the Commit includes an
+   UpdatePath, a "provisional" group context is constructed that
+   reflects changes due to the proposals and UpdatePath, but with the
+   old confirmed transcript hash.
+
+   A member of the group creates a Commit message and the corresponding
+   Welcome message at the same time, by taking the following steps:
+
+   *  Verify that the list of proposals to be committed is valid as
+      specified in Section 12.2.
+
+   *  Construct an initial Commit object with the proposals field
+      populated from Proposals received during the current epoch, and
+      with the path field empty.
+
+   *  Create the new ratchet tree and GroupContext by applying the list
+      of proposals to the old ratchet tree and GroupContext, as defined
+      in Section 12.3.
+
+   *  Decide whether to populate the path field: If the path field is
+      required based on the proposals that are in the Commit (see
+      above), then it MUST be populated.  Otherwise, the sender MAY omit
+      the path field at its discretion.
+
+   *  If populating the path field:
+
+      -  If this is an external Commit, assign the sender the leftmost
+         blank leaf node in the new ratchet tree.  If there are no blank
+         leaf nodes in the new ratchet tree, expand the tree to the
+         right as defined in Section 7.7 and assign the leftmost new
+         blank leaf to the sender.
+
+      -  Update the sender's direct path in the ratchet tree as
+         described in Section 7.5.  Define commit_secret as the value
+         path_secret[n+1] derived from the last path secret value
+         (path_secret[n]) derived for the UpdatePath.
+
+      -  Construct a provisional GroupContext object containing the
+         following values:
+
+         o  group_id: Same as the old GroupContext
+
+         o  epoch: The epoch number for the new epoch
+
+         o  tree_hash: The tree hash of the new ratchet tree
+
+         o  confirmed_transcript_hash: Same as the old GroupContext
+
+         o  extensions: The new GroupContext extensions (possibly
+            updated by a GroupContextExtensions proposal)
+
+      -  Encrypt the path secrets resulting from the tree update to the
+         group as described in Section 7.5, using the provisional group
+         context as the context for HPKE encryption.
+
+      -  Create an UpdatePath containing the sender's new leaf node and
+         the new public keys and encrypted path secrets along the
+         sender's filtered direct path.  Assign this UpdatePath to the
+         path field in the Commit.
+
+   *  If not populating the path field: Set the path field in the Commit
+      to the null optional.  Define commit_secret as the all-zero vector
+      of length KDF.Nh (the same length as a path_secret value would
+      be).
+
+   *  Derive the psk_secret as specified in Section 8.4, where the order
+      of PSKs in the derivation corresponds to the order of PreSharedKey
+      proposals in the proposals vector.
+
+   *  Construct a FramedContent object containing the Commit object.
+      Sign the FramedContent using the old GroupContext as context.
+
+      -  Use the FramedContent to update the confirmed transcript hash
+         and update the new GroupContext.
+
+      -  Use the init_secret from the previous epoch, the commit_secret
+         and psk_secret defined in the previous steps, and the new
+         GroupContext to compute the new joiner_secret, welcome_secret,
+         epoch_secret, and derived secrets for the new epoch.
+
+      -  Use the confirmation_key for the new epoch to compute the
+         confirmation_tag value.
+
+      -  Calculate the interim transcript hash using the new confirmed
+         transcript hash and the confirmation_tag from the
+         FramedContentAuthData.
+
+   *  Protect the AuthenticatedContent object using keys from the old
+      epoch:
+
+      -  If encoding as PublicMessage, compute the membership_tag value
+         using the membership_key.
+
+      -  If encoding as a PrivateMessage, encrypt the message using the
+         sender_data_secret and the next (key, nonce) pair from the
+         sender's handshake ratchet.
+
+   *  Construct a GroupInfo reflecting the new state:
+
+      -  Set the group_id, epoch, tree, confirmed_transcript_hash,
+         interim_transcript_hash, and group_context_extensions fields to
+         reflect the new state.
+
+      -  Set the confirmation_tag field to the value of the
+         corresponding field in the FramedContentAuthData object.
+
+      -  Add any other extensions as defined by the application.
+
+      -  Optionally derive an external key pair as described in
+         Section 8. (required for external Commits, see
+         Section 12.4.3.2).
+
+      -  Sign the GroupInfo using the member's private signing key.
+
+      -  Encrypt the GroupInfo using the key and nonce derived from the
+         joiner_secret. for the new epoch (see Section 12.4.3.1).
+
+   *  For each new member in the group:
+
+      -  Identify the lowest common ancestor in the tree of the new
+         member's leaf node and the member sending the Commit.
+
+      -  If the path field was populated above: Compute the path secret
+         corresponding to the common ancestor node.
+
+      -  Compute an EncryptedGroupSecrets object that encapsulates the
+         init_secret for the current epoch and the path secret (if
+         present).
+
+   *  Construct one or more Welcome messages from the encrypted
+      GroupInfo object, the encrypted key packages, and any PSKs for
+      which a proposal was included in the Commit.  The order of the
+      psks MUST be the same as the order of PreSharedKey proposals in
+      the proposals vector.  As discussed in Section 12.4.3.1, the
+      committer is free to choose how many Welcome messages to
+      construct.  However, the set of Welcome messages produced in this
+      step MUST cover every new member added in the Commit.
+
+   *  If a ReInit proposal was part of the Commit, the committer MUST
+      create a new group with the parameters specified in the ReInit
+      proposal, and with the same members as the original group.  The
+      Welcome message MUST include a PreSharedKeyID with the following
+      parameters:
+
+      -  psktype: resumption
+
+      -  usage: reinit
+
+      -  group_id: The group ID for the current group
+
+      -  epoch: The epoch that the group will be in after this Commit
+
+12.4.2.  Processing a Commit
+
+   A member of the group applies a Commit message by taking the
+   following steps:
+
+   *  Verify that the epoch field of the enclosing FramedContent is
+      equal to the epoch field of the current GroupContext object.
+
+   *  Unprotect the Commit using the keys from the current epoch:
+
+      -  If the message is encoded as PublicMessage, verify the
+         membership MAC using the membership_key.
+
+      -  If the message is encoded as PrivateMessage, decrypt the
+         message using the sender_data_secret and the (key, nonce) pair
+         from the step on the sender's hash ratchet indicated by the
+         generation field.
+
+   *  Verify the signature on the FramedContent message as described in
+      Section 6.1.
+
+   *  Verify that the proposals vector is valid according to the rules
+      in Section 12.2.
+
+   *  Verify that all PreSharedKey proposals in the proposals vector are
+      available.
+
+   *  Create the new ratchet tree and GroupContext by applying the list
+      of proposals to the old ratchet tree and GroupContext, as defined
+      in Section 12.3.
+
+   *  Verify that the path value is populated if the proposals vector
+      contains any Update or Remove proposals, or if it's empty.
+      Otherwise, the path value MAY be omitted.
+
+   *  If the path value is populated, validate it and apply it to the
+      tree:
+
+      -  If this is an external Commit, assign the sender the leftmost
+         blank leaf node in the new ratchet tree.  If there are no blank
+         leaf nodes in the new ratchet tree, add a blank leaf to the
+         right side of the new ratchet tree and assign it to the sender.
+
+      -  Validate the LeafNode as specified in Section 7.3.  The
+         leaf_node_source field MUST be set to commit.
+
+      -  Verify that the encryption_key value in the LeafNode is
+         different from the committer's current leaf node.
+
+      -  Verify that none of the public keys in the UpdatePath appear in
+         any node of the new ratchet tree.
+
+      -  Merge the UpdatePath into the new ratchet tree, as described in
+         Section 7.5.
+
+      -  Construct a provisional GroupContext object containing the
+         following values:
+
+         o  group_id: Same as the old GroupContext
+
+         o  epoch: The epoch number for the new epoch
+
+         o  tree_hash: The tree hash of the new ratchet tree
+
+         o  confirmed_transcript_hash: Same as the old GroupContext
+
+         o  extensions: The new GroupContext extensions (possibly
+            updated by a GroupContextExtensions proposal)
+
+      -  Decrypt the path secrets for UpdatePath as described in
+         Section 7.5, using the provisional GroupContext as the context
+         for HPKE decryption.
+
+      -  Define commit_secret as the value path_secret[n+1] derived from
+         the last path secret value (path_secret[n]) derived for the
+         UpdatePath.
+
+   *  If the path value is not populated, define commit_secret as the
+      all-zero vector of length KDF.Nh (the same length as a path_secret
+      value would be).
+
+   *  Update the confirmed and interim transcript hashes using the new
+      Commit, and generate the new GroupContext.
+
+   *  Derive the psk_secret as specified in Section 8.4, where the order
+      of PSKs in the derivation corresponds to the order of PreSharedKey
+      proposals in the proposals vector.
+
+   *  Use the init_secret from the previous epoch, the commit_secret and
+      psk_secret defined in the previous steps, and the new GroupContext
+      to compute the new joiner_secret, welcome_secret, epoch_secret,
+      and derived secrets for the new epoch.
+
+   *  Use the confirmation_key for the new epoch to compute the
+      confirmation tag for this message, as described below, and verify
+      that it is the same as the confirmation_tag field in the
+      FramedContentAuthData object.
+
+   *  If the above checks are successful, consider the new GroupContext
+      object as the current state of the group.
+
+   *  If the Commit included a ReInit proposal, the client MUST NOT use
+      the group to send messages anymore.  Instead, it MUST wait for a
+      Welcome message from the committer meeting the requirements of
+      Section 11.2.
+
+   Note that clients need to be prepared to receive a valid Commit
+   message that removes them from the group.  In this case, the client
+   cannot send any more messages in the group and SHOULD promptly delete
+   its group state and secret tree.  (A client might keep the secret
+   tree for a short time to decrypt late messages in the previous
+   epoch.)
+
+12.4.3.  Adding Members to the Group
+
+   New members can join the group in two ways: by being added by a group
+   member or by adding themselves through an external Commit.  In both
+   cases, the new members need information to bootstrap their local
+   group state.
+
+   struct {
+       GroupContext group_context;
+       Extension extensions<V>;
+       MAC confirmation_tag;
+       uint32 signer;
+       /* SignWithLabel(., "GroupInfoTBS", GroupInfoTBS) */
+       opaque signature<V>;
+   } GroupInfo;
+
+   The group_context field represents the current state of the group.
+   The extensions field allows the sender to provide additional data
+   that might be useful to new joiners.  The confirmation_tag represents
+   the confirmation tag from the Commit that initiated the current
+   epoch, or for epoch 0, the confirmation tag computed in the creation
+   of the group (see Section 11).  (In either case, the creator of a
+   GroupInfo may recompute the confirmation tag as MAC(confirmation_key,
+   confirmed_transcript_hash).)
+
+   As discussed in Section 13, unknown extensions in
+   GroupInfo.extensions MUST be ignored, and the creator of a GroupInfo
+   object SHOULD include some random GREASE extensions to help ensure
+   that other clients correctly ignore unknown extensions.  Extensions
+   in GroupInfo.group_context.extensions, however, MUST be supported by
+   the new joiner.
+
+   New members MUST verify that group_id is unique among the groups they
+   are currently participating in.
+
+   New members also MUST verify the signature using the public key taken
+   from the leaf node of the ratchet tree with leaf index signer.  The
+   signature covers the following structure, comprising all the fields
+   in the GroupInfo above signature:
+
+   struct {
+       GroupContext group_context;
+       Extension extensions<V>;
+       MAC confirmation_tag;
+       uint32 signer;
+   } GroupInfoTBS;
+
+12.4.3.1.  Joining via Welcome Message
+
+   The sender of a Commit message is responsible for sending a Welcome
+   message to each new member added via Add proposals.  The format of
+   the Welcome message allows a single Welcome message to be encrypted
+   for multiple new members.  It is up to the committer to decide how
+   many Welcome messages to create for a given Commit.  The committer
+   could create one Welcome that is encrypted for all new members, a
+   different Welcome for each new member, or Welcome messages for
+   batches of new members (according to some batching scheme that works
+   well for the application).  The processes for creating and processing
+   the Welcome are the same in all cases, aside from the set of new
+   members for whom a given Welcome is encrypted.
+
+   The Welcome message provides the new members with the current state
+   of the group after the application of the Commit message.  The new
+   members will not be able to decrypt or verify the Commit message, but
+   they will have the secrets they need to participate in the epoch
+   initiated by the Commit message.
+
+   In order to allow the same Welcome message to be sent to multiple new
+   members, information describing the group is encrypted with a
+   symmetric key and nonce derived from the joiner_secret for the new
+   epoch.  The joiner_secret is then encrypted to each new member using
+   HPKE.  In the same encrypted package, the committer transmits the
+   path secret for the lowest (closest to the leaf) node that is
+   contained in the direct paths of both the committer and the new
+   member.  This allows the new member to compute private keys for nodes
+   in its direct path that are being reset by the corresponding Commit.
+
+   If the sender of the Welcome message wants the receiving member to
+   include a PSK in the derivation of the epoch_secret, they can
+   populate the psks field indicating which PSK to use.
+
+   struct {
+     opaque path_secret<V>;
+   } PathSecret;
+
+   struct {
+     opaque joiner_secret<V>;
+     optional<PathSecret> path_secret;
+     PreSharedKeyID psks<V>;
+   } GroupSecrets;
+
+   struct {
+     KeyPackageRef new_member;
+     HPKECiphertext encrypted_group_secrets;
+   } EncryptedGroupSecrets;
+
+   struct {
+     CipherSuite cipher_suite;
+     EncryptedGroupSecrets secrets<V>;
+     opaque encrypted_group_info<V>;
+   } Welcome;
+
+   The client processing a Welcome message will need to have a copy of
+   the group's ratchet tree.  The tree can be provided in the Welcome
+   message, in an extension of type ratchet_tree.  If it is sent
+   otherwise (e.g., provided by a caching service on the Delivery
+   Service), then the client MUST download the tree before processing
+   the Welcome.
+
+   On receiving a Welcome message, a client processes it using the
+   following steps:
+
+   *  Identify an entry in the secrets array where the new_member value
+      corresponds to one of this client's KeyPackages, using the hash
+      indicated by the cipher_suite field.  If no such field exists, or
+      if the cipher suite indicated in the KeyPackage does not match the
+      one in the Welcome message, return an error.
+
+   *  Decrypt the encrypted_group_secrets value with the algorithms
+      indicated by the cipher suite and the private key init_key_priv
+      corresponding to init_key in the referenced KeyPackage.
+
+   encrypted_group_secrets =
+     EncryptWithLabel(init_key, "Welcome",
+                      encrypted_group_info, group_secrets)
+
+   group_secrets =
+     DecryptWithLabel(init_key_priv, "Welcome",
+                      encrypted_group_info, kem_output, ciphertext)
+
+   *  If a PreSharedKeyID is part of the GroupSecrets and the client is
+      not in possession of the corresponding PSK, return an error.
+      Additionally, if a PreSharedKeyID has type resumption with usage
+      reinit or branch, verify that it is the only such PSK.
+
+   *  From the joiner_secret in the decrypted GroupSecrets object and
+      the PSKs specified in the GroupSecrets, derive the welcome_secret
+      and then the welcome_key and welcome_nonce.  Use the key and nonce
+      to decrypt the encrypted_group_info field.
+
+   welcome_nonce = ExpandWithLabel(welcome_secret, "nonce", "", AEAD.Nn)
+   welcome_key = ExpandWithLabel(welcome_secret, "key", "", AEAD.Nk)
+
+   *  Verify the signature on the GroupInfo object.  The signature input
+      comprises all of the fields in the GroupInfo object except the
+      signature field.  The public key is taken from the LeafNode of the
+      ratchet tree with leaf index signer.  If the node is blank or if
+      signature verification fails, return an error.
+
+   *  Verify that the group_id is unique among the groups that the
+      client is currently participating in.
+
+   *  Verify that the cipher_suite in the GroupInfo matches the
+      cipher_suite in the KeyPackage.
+
+   *  Verify the integrity of the ratchet tree.
+
+      -  Verify that the tree hash of the ratchet tree matches the
+         tree_hash field in GroupInfo.
+
+      -  For each non-empty parent node, verify that it is "parent-hash
+         valid", as described in Section 7.9.2.
+
+      -  For each non-empty leaf node, validate the LeafNode as
+         described in Section 7.3.
+
+      -  For each non-empty parent node and each entry in the node's
+         unmerged_leaves field:
+
+         o  Verify that the entry represents a non-blank leaf node that
+            is a descendant of the parent node.
+
+         o  Verify that every non-blank intermediate node between the
+            leaf node and the parent node also has an entry for the leaf
+            node in its unmerged_leaves.
+
+         o  Verify that the encryption key in the parent node does not
+            appear in any other node of the tree.
+
+   *  Identify a leaf whose LeafNode is identical to the one in the
+      KeyPackage.  If no such field exists, return an error.  Let
+      my_leaf represent this leaf in the tree.
+
+   *  Construct a new group state using the information in the GroupInfo
+      object.
+
+      -  Initialize the GroupContext for the group from the
+         group_context field from the GroupInfo object.
+
+      -  Update the leaf my_leaf with the private key corresponding to
+         the public key in the node, where my_leaf is the new member's
+         leaf node in the ratchet tree, as defined above.
+
+      -  If the path_secret value is set in the GroupSecrets object:
+         Identify the lowest common ancestor of the leaf node my_leaf
+         and of the node of the member with leaf index GroupInfo.signer.
+         Set the private key for this node to the private key derived
+         from the path_secret.
+
+      -  For each parent of the common ancestor, up to the root of the
+         tree, derive a new path secret, and set the private key for the
+         node to the private key derived from the path secret.  The
+         private key MUST be the private key that corresponds to the
+         public key in the node.
+
+   *  Use the joiner_secret from the GroupSecrets object to generate the
+      epoch secret and other derived secrets for the current epoch.
+
+   *  Set the confirmed transcript hash in the new state to the value of
+      the confirmed_transcript_hash in the GroupInfo.
+
+   *  Verify the confirmation tag in the GroupInfo using the derived
+      confirmation key and the confirmed_transcript_hash from the
+      GroupInfo.
+
+   *  Use the confirmed transcript hash and confirmation tag to compute
+      the interim transcript hash in the new state.
+
+   *  If a PreSharedKeyID was used that has type resumption with usage
+      reinit or branch, verify that the epoch field in the GroupInfo is
+      equal to 1.
+
+      -  For usage reinit, verify that the last Commit to the referenced
+         group contains a ReInit proposal and that the group_id,
+         version, cipher_suite, and group_context.extensions fields of
+         the GroupInfo match the ReInit proposal.  Additionally, verify
+         that all the members of the old group are also members of the
+         new group, according to the application.
+
+      -  For usage branch, verify that the version and cipher_suite of
+         the new group match those of the old group, and that the
+         members of the new group compose a subset of the members of the
+         old group, according to the application.
+
+12.4.3.2.  Joining via External Commits
+
+   External Commits are a mechanism for new members (external parties
+   that want to become members of the group) to add themselves to a
+   group, without requiring that an existing member has to come online
+   to issue a Commit that references an Add proposal.
+
+   Whether existing members of the group will accept or reject an
+   external Commit follows the same rules that are applied to other
+   handshake messages.
+
+   New members can create and issue an external Commit if they have
+   access to the following information for the group's current epoch:
+
+   *  group ID
+
+   *  epoch ID
+
+   *  cipher suite
+
+   *  public tree hash
+
+   *  confirmed transcript hash
+
+   *  confirmation tag of the most recent Commit
+
+   *  group extensions
+
+   *  external public key
+
+   In other words, to join a group via an external Commit, a new member
+   needs a GroupInfo with an external_pub extension present in its
+   extensions field.
+
+   struct {
+       HPKEPublicKey external_pub;
+   } ExternalPub;
+
+   Thus, a member of the group can enable new clients to join by making
+   a GroupInfo object available to them.  Note that because a GroupInfo
+   object is specific to an epoch, it will need to be updated as the
+   group advances.  In particular, each GroupInfo object can be used for
+   one external join, since that external join will cause the epoch to
+   change.
+
+   Note that the tree_hash field is used the same way as in the Welcome
+   message.  The full tree can be included via the ratchet_tree
+   extension (see Section 12.4.3.3).
+
+   The information in a GroupInfo is not generally public information,
+   but applications can choose to make it available to new members in
+   order to allow External Commits.
+
+   In principle, external Commits work like regular Commits.  However,
+   their content has to meet a specific set of requirements:
+
+   *  External Commits MUST contain a path field (and is therefore a
+      "full" Commit).  The joiner is added at the leftmost free leaf
+      node (just as if they were added with an Add proposal), and the
+      path is calculated relative to that leaf node.
+
+   *  The Commit MUST NOT include any proposals by reference, since an
+      external joiner cannot determine the validity of proposals sent
+      within the group.
+
+   *  External Commits MUST be signed by the new member.  In particular,
+      the signature on the enclosing AuthenticatedContent MUST verify
+      using the public key for the credential in the leaf_node of the
+      path field.
+
+   *  When processing a Commit, both existing and new members MUST use
+      the external init secret as described in Section 8.3.
+
+   *  The sender type for the AuthenticatedContent encapsulating the
+      external Commit MUST be new_member_commit.
+
+   External Commits come in two "flavors" -- a "join" Commit that adds
+   the sender to the group or a "resync" Commit that replaces a member's
+   prior appearance with a new one.
+
+   Note that the "resync" operation allows an attacker that has
+   compromised a member's signature private key to introduce themselves
+   into the group and remove the prior, legitimate member in a single
+   Commit.  Without resync, this can still be done, but it requires two
+   operations: the external Commit to join and a second Commit to remove
+   the old appearance.  Applications for whom this distinction is
+   salient can choose to disallow external commits that contain a
+   Remove, or to allow such resync commits only if they contain a
+   "reinit" PSK proposal that demonstrates the joining member's presence
+   in a prior epoch of the group.  With the latter approach, the
+   attacker would need to compromise the PSK as well as the signing key,
+   but the application will need to ensure that continuing, non-
+   resynchronizing members have the required PSK.
+
+12.4.3.3.  Ratchet Tree Extension
+
+   By default, a GroupInfo message only provides the joiner with a hash
+   of the group's ratchet tree.  In order to process or generate
+   handshake messages, the joiner will need to get a copy of the ratchet
+   tree from some other source.  (For example, the DS might provide a
+   cached copy.)  The inclusion of the tree hash in the GroupInfo
+   message means that the source of the ratchet tree need not be trusted
+   to maintain the integrity of the tree.
+
+   In cases where the application does not wish to provide such an
+   external source, the whole public state of the ratchet tree can be
+   provided in an extension of type ratchet_tree, containing a
+   ratchet_tree object of the following form:
+
+   struct {
+       NodeType node_type;
+       select (Node.node_type) {
+           case leaf:   LeafNode leaf_node;
+           case parent: ParentNode parent_node;
+       };
+   } Node;
+
+   optional<Node> ratchet_tree<V>;
+
+   Each entry in the ratchet_tree vector provides the value for a node
+   in the tree, or the null optional for a blank node.
+
+   The nodes are listed in the order specified by a left-to-right in-
+   order traversal of the ratchet tree.  Each node is listed between its
+   left subtree and its right subtree.  (This is the same ordering as
+   specified for the array-based trees outlined in Appendix C.)
+
+   If the tree has 2^d leaves, then it has 2^(d+1) - 1 nodes.  The
+   ratchet_tree vector logically has this number of entries, but the
+   sender MUST NOT include blank nodes after the last non-blank node.
+   The receiver MUST check that the last node in ratchet_tree is non-
+   blank, and then extend the tree to the right until it has a length of
+   the form 2^(d+1) - 1, adding the minimum number of blank values
+   possible.  (Obviously, this may be done "virtually", by synthesizing
+   blank nodes when required, as opposed to actually changing the
+   structure in memory.)
+
+   The leaves of the tree are stored in even-numbered entries in the
+   array (the leaf with index L in array position 2*L).  The root node
+   of the tree is at position 2^d - 1 of the array.  Intermediate parent
+   nodes can be identified by performing the same calculation to the
+   subarrays to the left and right of the root, following something like
+   the following algorithm:
+
+   # Assuming a class Node that has left and right members
+   def subtree_root(nodes):
+       # If there is only one node in the array, return it
+       if len(nodes) == 1:
+           return Node(nodes[0])
+
+       # Otherwise, the length of the array MUST be odd
+       if len(nodes) % 2 == 0:
+           raise Exception("Malformed node array {}", len(nodes))
+
+       # Identify the root of the subtree
+       d = 0
+       while (2**(d+1)) < len(nodes):
+          d += 1
+       R = 2**d - 1
+       root = Node(nodes[R])
+       root.left = subtree_root(nodes[:R])
+       root.right = subtree_root(nodes[(R+1):])
+       return root
+
+   (Note that this is the same ordering of nodes as in the array-based
+   tree representation described in Appendix C.  The algorithms in that
+   section may be used to simplify decoding this extension into other
+   representations.)
+
+   For example, the following tree with six non-blank leaves would be
+   represented as an array of eleven elements, [A, W, B, X, C, _, D, Y,
+   E, Z, F].  The above decoding procedure would identify the subtree
+   roots as follows (using R to represent a subtree root):
+
+                 Y
+                 |
+           .-----+-----.
+          /             \
+         X               _
+         |               |
+       .-+-.           .-+-.
+      /     \         /     \
+     W       _       Z       _
+    / \     / \     / \     / \
+   A   B   C   D   E   F   _   _
+
+                       1
+   0 1 2 3 4 5 6 7 8 9 0
+   <-----------> R <----------->
+   <---> R <--->   <---> R <--->
+   - R -   - R -   - R -   - R -
+
+      Figure 28: Left-to-Right In-Order Traversal of a Six-Member Tree
+
+   The presence of a ratchet_tree extension in a GroupInfo message does
+   not result in any changes to the GroupContext extensions for the
+   group.  The ratchet tree provided is simply stored by the client and
+   used for MLS operations.
+
+   If this extension is not provided in a Welcome message, then the
+   client will need to fetch the ratchet tree over some other channel
+   before it can generate or process Commit messages.  Applications
+   should ensure that this out-of-band channel is provided with security
+   protections equivalent to the protections that are afforded to
+   Proposal and Commit messages.  For example, an application that
+   encrypts Proposal and Commit messages might distribute ratchet trees
+   encrypted using a key exchanged over the MLS channel.
+
+   Regardless of how the client obtains the tree, the client MUST verify
+   that the root hash of the ratchet tree matches the tree_hash of the
+   GroupContext before using the tree for MLS operations.
+
+13.  Extensibility
+
+   The base MLS protocol can be extended in a few ways.  New cipher
+   suites can be added to enable the use of new cryptographic
+   algorithms.  New types of proposals can be used to perform new
+   actions within an epoch.  Extension fields can be used to add
+   additional information to the protocol.  In this section, we discuss
+   some constraints on these extensibility mechanisms that are necessary
+   to ensure broad interoperability.
+
+13.1.  Additional Cipher Suites
+
+   As discussed in Section 5.1, MLS allows the participants in a group
+   to negotiate the cryptographic algorithms used within the group.
+   This extensibility is important for maintaining the security of the
+   protocol over time [RFC7696].  It also creates a risk of
+   interoperability failure due to clients not supporting a common
+   cipher suite.
+
+   The cipher suite registry defined in Section 17.1 attempts to strike
+   a balance on this point.  On the one hand, the base policy for the
+   registry is Specification Required, a fairly low bar designed to
+   avoid the need for standards work in cases where different ciphers
+   are needed for niche applications.  On the other hand, there is a
+   higher bar (Standards Action) for ciphers to set the Recommended
+   field in the registry.  This higher bar is there in part to ensure
+   that the interoperability implications of new cipher suites are
+   considered.
+
+   MLS cipher suites are defined independent of MLS versions, so that in
+   principle, the same cipher suite can be used across versions.
+   Standards work defining new versions of MLS should consider whether
+   it is desirable for the new version to be compatible with existing
+   cipher suites, or whether the new version should rule out some cipher
+   suites.  For example, a new version could follow the example of
+   HTTP/2, which restricted the set of allowed TLS ciphers (see
+   Section 9.2.2 of [RFC9113]).
+
+13.2.  Proposals
+
+   Commit messages do not have an extension field because the set of
+   proposals is extensible.  As discussed in Section 12.4, Proposals
+   with a non-default proposal type MUST NOT be included in a commit
+   unless the proposal type is supported by all the members of the group
+   that will process the Commit.
+
+13.3.  Credential Extensibility
+
+   In order to ensure that MLS provides meaningful authentication, it is
+   important that each member is able to authenticate some identity
+   information for each other member.  Identity information is encoded
+   in Credentials, so this property is provided by ensuring that members
+   use compatible credential types.
+
+   The only types of credential that may be used in a group are those
+   that all members of the group support, as specified by the
+   capabilities field of each LeafNode in the ratchet tree.  An
+   application can introduce new credential types by choosing an
+   unallocated identifier from the registry in Section 17.5 and
+   indicating support for the credential type in published LeafNodes,
+   whether in Update proposals to existing groups or KeyPackages that
+   are added to new groups.  Once all members in a group indicate
+   support for the credential type, members can start using LeafNodes
+   with the new credential.  Application may enforce that certain
+   credential types always remain supported by adding a
+   required_capabilities extension to the group's GroupContext, which
+   would prevent any member from being added to the group that doesn't
+   support them.
+
+   In future extensions to MLS, it may be useful to allow a member to
+   present more than one credential.  For example, such credentials
+   might present different attributes attested by different authorities.
+   To be consistent with the general principle stated at the beginning
+   of this section, such an extension would need to ensure that each
+   member can authenticate some identity for each other member.  For
+   each pair of members (Alice, Bob), Alice would need to present at
+   least one credential of a type that Bob supports.
+
+13.4.  Extensions
+
+   This protocol includes a mechanism for negotiating extension
+   parameters similar to the one in TLS [RFC8446].  In TLS, extension
+   negotiation is one-to-one: The client offers extensions in its
+   ClientHello message, and the server expresses its choices for the
+   session with extensions in its ServerHello and EncryptedExtensions
+   messages.  In MLS, extensions appear in the following places:
+
+   *  In KeyPackages, to describe additional information related to the
+      client
+
+   *  In LeafNodes, to describe additional information about the client
+      or its participation in the group (once in the ratchet tree)
+
+   *  In the GroupInfo, to tell new members of a group what parameters
+      are being used by the group, and to provide any additional details
+      required to join the group
+
+   *  In the GroupContext object, to ensure that all members of the
+      group have the same view of the parameters in use
+
+   In other words, an application can use GroupContext extensions to
+   ensure that all members of the group agree on a set of parameters.
+   Clients indicate their support for parameters in the capabilities
+   field of their LeafNode.  New members of a group are informed of the
+   group's GroupContext extensions via the extensions field in the
+   group_context field of the GroupInfo object.  The extensions field in
+   a GroupInfo object (outside of the group_context field) can be used
+   to provide additional parameters to new joiners that are used to join
+   the group.
+
+   This extension mechanism is designed to allow for the secure and
+   forward-compatible negotiation of extensions.  For this to work,
+   implementations MUST correctly handle extensible fields:
+
+   *  A client that posts a KeyPackage MUST support all parameters
+      advertised in it.  Otherwise, another client might fail to
+      interoperate by selecting one of those parameters.
+
+   *  A client processing a KeyPackage object MUST ignore all
+      unrecognized values in the capabilities field of the LeafNode and
+      all unknown extensions in the extensions and leaf_node.extensions
+      fields.  Otherwise, it could fail to interoperate with newer
+      clients.
+
+   *  A client processing a GroupInfo object MUST ignore all
+      unrecognized extensions in the extensions field.
+
+   *  Any field containing a list of extensions MUST NOT have more than
+      one extension of any given type.
+
+   *  A client adding a new member to a group MUST verify that the
+      LeafNode for the new member is compatible with the group's
+      extensions.  The capabilities field MUST indicate support for each
+      extension in the GroupContext.
+
+   *  A client joining a group MUST verify that it supports every
+      extension in the GroupContext for the group.  Otherwise, it MUST
+      treat the enclosing GroupInfo message as invalid and not join the
+      group.
+
+   Note that the latter two requirements mean that all MLS GroupContext
+   extensions are mandatory, in the sense that an extension in use by
+   the group MUST be supported by all members of the group.
+
+   The parameters of a group may be changed by sending a
+   GroupContextExtensions proposal to enable additional extensions
+   (Section 12.1.7), or by reinitializing the group (Section 11.2).
+
+13.5.  GREASE
+
+   As described in Section 13.4, clients are required to ignore unknown
+   values for certain parameters.  To help ensure that other clients
+   implement this behavior, a client can follow the "Generate Random
+   Extensions And Sustain Extensibility" or GREASE approach described in
+   [RFC8701].  In the context of MLS, this means that a client
+   generating a KeyPackage, LeafNode, or GroupInfo object includes
+   random values in certain fields which would be ignored by a correctly
+   implemented client processing the message.  A client that incorrectly
+   rejects unknown code points will fail to process such a message,
+   providing a signal to its implementer that the client needs to be
+   fixed.
+
+   When generating the following fields, an MLS client SHOULD include a
+   random selection of values chosen from these GREASE values:
+
+   *  LeafNode.capabilities.cipher_suites
+
+   *  LeafNode.capabilities.extensions
+
+   *  LeafNode.capabilities.proposals
+
+   *  LeafNode.capabilities.credentials
+
+   *  LeafNode.extensions
+
+   *  KeyPackage.extensions
+
+   *  GroupInfo.extensions
+
+   For the KeyPackage and GroupInfo extensions, the extension_data for
+   GREASE extensions MAY have any contents selected by the sender, since
+   they will be ignored by a correctly implemented receiver.  For
+   example, a sender might populate these extensions with a randomly
+   sized amount of random data.
+
+   Note that any GREASE values added to LeafNode.extensions need to be
+   reflected in LeafNode.capabilities.extensions, since the LeafNode
+   validation process described in Section 7.3 requires that these two
+   fields be consistent.
+
+   GREASE values MUST NOT be sent in the following fields, because an
+   unsupported value in one these fields (including a GREASE value) will
+   cause the enclosing message to be rejected:
+
+   *  Proposal.proposal_type
+
+   *  Credential.credential_type
+
+   *  GroupContext.extensions
+
+   *  GroupContextExtensions.extensions
+
+   Values reserved for GREASE have been registered in the various
+   registries in Section 17.  This prevents conflict between GREASE and
+   real future values.  The following values are reserved in each
+   registry: 0x0A0A, 0x1A1A, 0x2A2A, 0x3A3A, 0x4A4A, 0x5A5A, 0x6A6A,
+   0x7A7A, 0x8A8A, 0x9A9A, 0xAAAA, 0xBABA, 0xCACA, 0xDADA, and 0xEAEA.
+   (The value 0xFAFA falls within the private use range.)  These values
+   MUST only appear in the fields listed above, and not, for example, in
+   the proposal_type field of a Proposal.  Clients MUST NOT implement
+   any special processing rules for how to handle these values when
+   receiving them, since this negates their utility for detecting
+   extensibility failures.
+
+   GREASE values MUST be handled using normal logic for processing
+   unsupported values.  When comparing lists of capabilities to identify
+   mutually supported capabilities, clients MUST represent their own
+   capabilities with a list containing only the capabilities actually
+   supported, without any GREASE values.  In other words, lists
+   including GREASE values are only sent to other clients;
+   representations of a client's own capabilities MUST NOT contain
+   GREASE values.
+
+14.  Sequencing of State Changes
+
+   Each Commit message is premised on a given starting state, indicated
+   by the epoch field of the enclosing FramedContent.  If the changes
+   implied by a Commit message are made starting from a different state,
+   the results will be incorrect.
+
+   This need for sequencing is not a problem as long as each time a
+   group member sends a Commit message, it is based on the most current
+   state of the group.  In practice, however, there is a risk that two
+   members will generate Commit messages simultaneously based on the
+   same state.
+
+   Applications MUST have an established way to resolve conflicting
+   Commit messages for the same epoch.  They can do this either by
+   preventing conflicting messages from occurring in the first place, or
+   by developing rules for deciding which Commit out of several sent in
+   an epoch will be canonical.  The approach chosen MUST minimize the
+   amount of time that forked or previous group states are kept in
+   memory, and promptly delete them once they're no longer necessary to
+   ensure forward secrecy.
+
+   The generation of Commit messages MUST NOT modify a client's state,
+   since the client doesn't know at that time whether the changes
+   implied by the Commit message will conflict with another Commit or
+   not.  Similarly, the Welcome message corresponding to a Commit MUST
+   NOT be delivered to a new joiner until it's clear that the Commit has
+   been accepted.
+
+   Regardless of how messages are kept in sequence, there is a risk that
+   in a sufficiently busy group, a given member may never be able to
+   send a Commit message because they always lose to other members.  The
+   degree to which this is a practical problem will depend on the
+   dynamics of the application.
+
+15.  Application Messages
+
+   The primary purpose of handshake messages is to provide an
+   authenticated group key exchange to clients.  In order to protect
+   application messages sent among the members of a group, the
+   encryption_secret provided by the key schedule is used to derive a
+   sequence of nonces and keys for message encryption.  Every epoch
+   moves the key schedule forward, which triggers the creation of a new
+   secret tree, as described in Section 9, along with a new set of
+   symmetric ratchets of nonces and keys for each member.
+
+   Each client maintains their own local copy of the key schedule for
+   each epoch during which they are a group member.  They derive new
+   keys, nonces, and secrets as needed while deleting old ones as soon
+   as they have been used.
+
+   The group identifier and epoch allow a recipient to know which group
+   secrets should be used and from which epoch_secret to start computing
+   other secrets.  The sender identifier and content type are used to
+   identify which symmetric ratchet to use from the secret tree.  The
+   generation counter determines how far into the ratchet to iterate in
+   order to produce the required nonce and key for encryption or
+   decryption.
+
+15.1.  Padding
+
+   Application messages MAY be padded to provide some resistance against
+   traffic analysis techniques over encrypted traffic [CLINIC] [HCJ16].
+   While MLS might deliver the same payload less frequently across a lot
+   of ciphertexts than traditional web servers, it might still provide
+   the attacker enough information to mount an attack.  If Alice asks
+   Bob "When are we going to the movie?", then the answer "Wednesday"
+   could be leaked to an adversary solely by the ciphertext length.
+
+   The length of the padding field in PrivateMessageContent can be
+   chosen by the sender at the time of message encryption.  Senders may
+   use padding to reduce the ability of attackers outside the group to
+   infer the size of the encrypted content.  Note, however, that the
+   transports used to carry MLS messages may have maximum message sizes,
+   so padding schemes SHOULD avoid increasing message size beyond any
+   such limits that exist in a given deployment scenario.
+
+15.2.  Restrictions
+
+   During each epoch, senders MUST NOT encrypt more data than permitted
+   by the security bounds of the AEAD scheme used [CFRG-AEAD-LIMITS].
+
+   Note that each change to the group through a handshake message will
+   also set a new encryption_secret.  Hence this change MUST be applied
+   before encrypting any new application message.  This is required both
+   to ensure that any users removed from the group can no longer receive
+   messages and to (potentially) recover confidentiality and
+   authenticity for future messages despite a past state compromise.
+
+15.3.  Delayed and Reordered Application Messages
+
+   Since each application message contains the group identifier, the
+   epoch, and a generation counter, a client can receive messages out of
+   order.  When messages are received out of order, the client moves the
+   sender ratchet forward to match the received generation counter.  Any
+   unused nonce and key pairs from the ratchet are potentially stored so
+   that they can be used to decrypt the messages that were delayed or
+   reordered.
+
+   Applications SHOULD define a policy on how long to keep unused nonce
+   and key pairs for a sender, and the maximum number to keep.  This is
+   in addition to ensuring that these secrets are deleted according to
+   the deletion schedule defined in Section 9.2.  Applications SHOULD
+   also define a policy limiting the maximum number of steps that
+   clients will move the ratchet forward in response to a new message.
+   Messages received with a generation counter that is too much higher
+   than the last message received would then be rejected.  This avoids
+   causing a denial-of-service attack by requiring the recipient to
+   perform an excessive number of key derivations.  For example, a
+   malicious group member could send a message with generation =
+   0xffffffff at the beginning of a new epoch, forcing recipients to
+   perform billions of key derivations unless they apply limits of the
+   type discussed above.
+
+16.  Security Considerations
+
+   The security goals of MLS are described in [MLS-ARCH].  We describe
+   here how the protocol achieves its goals at a high level, though a
+   complete security analysis is outside of the scope of this document.
+   The Security Considerations section of [MLS-ARCH] provides some
+   citations to detailed security analyses.
+
+16.1.  Transport Security
+
+   Because MLS messages are protected at the message level, the
+   confidentiality and integrity of the group state do not depend on
+   those messages being protected in transit.  However, an attacker who
+   can observe those messages in transit will be able to learn about the
+   group state, including potentially the group membership (see
+   Section 16.4.3 below).  Such an attacker might also be able to mount
+   denial-of-service attacks on the group or exclude new members by
+   selectively removing messages in transit.  In order to prevent this
+   form of attack, it is RECOMMENDED that all MLS messages be carried
+   over a secure transport such as TLS [RFC8446] or QUIC [RFC9000].
+
+16.2.  Confidentiality of Group Secrets
+
+   Group secrets are partly derived from the output of a ratchet tree.
+   Ratchet trees work by assigning each member of the group to a leaf in
+   the tree and maintaining the following property: the private key of a
+   node in the tree is known only to members of the group that are
+   assigned a leaf in the node's subtree.  This is called the _tree
+   invariant_, and it makes it possible to encrypt to all group members
+   except one, with a number of ciphertexts that is logarithmic in the
+   number of group members.
+
+   The ability to efficiently encrypt to all members except one allows
+   members to be securely removed from a group.  It also allows a member
+   to rotate their key pair such that the old private key can no longer
+   be used to decrypt new messages.
+
+16.3.  Confidentiality of Sender Data
+
+   The PrivateMessage framing encrypts "sender data" that identifies
+   which group member sent an encrypted message, as described in
+   Section 6.3.2.  As with the QUIC header protection scheme [RFC9001],
+   Section 5.4, this scheme is a variant of the HN1 construction
+   analyzed in [NAN].  A sample of the ciphertext is combined with a
+   sender_data_secret to derive a key and nonce that are used for AEAD
+   encryption of the sender data.
+
+   (key, nonce) = PRF(sender_data_secret, sample)
+   encrypted_sender_data =
+     AEAD.Seal(key, nonce, sender_data_aad, sender_data)
+
+   The only differences between this construction and HN1 as described
+   in [NAN] are that it (1) uses authenticated encryption instead of
+   unauthenticated encryption and (2) protects information used to
+   derive a nonce instead of the nonce itself.
+
+   Since the sender_data_secret is distinct from the content encryption
+   key, it follows that the sender data encryption scheme achieves AE2
+   security as defined in [NAN], and therefore guarantees the
+   confidentiality of the sender data.
+
+   Use of the same sender_data_secret and ciphertext sample more than
+   once risks compromising sender data protection by reusing an AEAD
+   (key, nonce) pair.  For example, in many AEAD schemes, reusing a key
+   and nonce reveals the exclusive OR of the two plaintexts.  Assuming
+   the ciphertext output of the AEAD algorithm is indistinguishable from
+   random data (i.e., the AEAD is AE1-secure in the phrasing of [NAN]),
+   the odds of two ciphertext samples being identical is roughly
+   2^(-L/2), i.e., the birthday bound.
+
+   The AEAD algorithms for cipher suites defined in this document all
+   provide this property.  The size of the sample depends on the cipher
+   suite's hash function, but in all cases, the probability of collision
+   is no more than 2^-128.  Any future cipher suite MUST use an
+   AE1-secure AEAD algorithm.
+
+16.4.  Confidentiality of Group Metadata
+
+   MLS does not provide confidentiality protection to some messages and
+   fields within messages:
+
+   *  KeyPackage messages
+
+   *  GroupInfo messages
+
+   *  The unencrypted portion of a Welcome message
+
+   *  Any Proposal or Commit messages sent as PublicMessage messages
+
+   *  The unencrypted header fields in PrivateMessage messages
+
+   *  The lengths of encrypted Welcome and PrivateMessage messages
+
+   The only mechanism MLS provides for confidentially distributing a
+   group's ratchet tree to new members is to send it in a Welcome
+   message as a ratchet_tree extension.  If an application distributes
+   the tree in some other way, its security will depend on that
+   application mechanism.
+
+   A party observing these fields might be able to infer certain
+   properties of the group:
+
+   *  Group ID
+
+   *  Current epoch and frequency of epoch changes
+
+   *  Frequency of messages within an epoch
+
+   *  Group extensions
+
+   *  Group membership
+
+   The amount of metadata exposed to parties outside the group, and thus
+   the ability of these parties to infer the group's properties, depends
+   on several aspects of the DS design, such as:
+
+   *  How KeyPackages are distributed
+
+   *  How the ratchet tree is distributed
+
+   *  How prospective external joiners get a GroupInfo object for the
+      group
+
+   *  Whether Proposal and Commit messages are sent as PublicMessage or
+      PrivateMessage
+
+   In the remainder of this section, we note the ways that the above
+   properties of the group are reflected in unprotected group messages,
+   as a guide to understanding how they might be exposed or protected in
+   a given application.
+
+16.4.1.  GroupID, Epoch, and Message Frequency
+
+   MLS provides no mechanism to protect the group ID and epoch of a
+   message from the DS, so the group ID and the frequency of messages
+   and epoch changes are not protected against inspection by the DS.
+   However, any modifications to these will cause decryption failure.
+
+16.4.2.  Group Extensions
+
+   A group's extensions are first set by the group's creator and then
+   updated by GroupContextExtensions proposals.  A
+   GroupContextExtensions proposal sent as a PublicMessage leaks the
+   group's extensions.
+
+   A new member learns the group's extensions via a GroupInfo object.
+   When the new member joins via a Welcome message, the Welcome
+   message's encryption protects the GroupInfo message.  When the new
+   member joins via an external join, they must be provided with a
+   GroupInfo object.  Protection of this GroupInfo object is up to the
+   application -- if it is transmitted over a channel that is not
+   confidential to the group and the new joiner, then it will leak the
+   group's extensions.
+
+16.4.3.  Group Membership
+
+   The group's membership is represented directly by its ratchet tree,
+   since each member's LeafNode contains members' cryptographic keys, a
+   credential that contains information about the member's identity, and
+   possibly other identifiers.  Applications that expose the group's
+   ratchet tree outside the group also leak the group's membership.
+
+   Changes to the group's membership are made by means of Add and Remove
+   proposals.  If these proposals are sent as PublicMessage, then
+   information will be leaked about the corresponding changes to the
+   group's membership.  A party that sees all of these changes can
+   reconstruct the group membership.
+
+   Welcome messages contain a hash of each KeyPackage for which the
+   Welcome message is encrypted.  If a party has access to a pool of
+   KeyPackages and observes a Welcome message, then they can identify
+   the KeyPackage representing the new member.  If the party can also
+   associate the Welcome with a group, then the party can infer that the
+   identified new member was added to that group.
+
+   Note that these information leaks reveal the group's membership only
+   to the degree that membership is revealed by the contents of a
+   member's LeafNode in the ratchet tree.  In some cases, this may be
+   quite direct, e.g., due to credentials attesting to identifiers such
+   as email addresses.  An application could construct a member's leaf
+   node to be less identifying, e.g., by using a pseudonymous credential
+   and frequently rotating encryption and signature keys.
+
+16.5.  Authentication
+
+   The first form of authentication we provide is that group members can
+   verify a message originated from one of the members of the group.
+   For encrypted messages, this is guaranteed because messages are
+   encrypted with an AEAD under a key derived from the group secrets.
+   For plaintext messages, this is guaranteed by the use of a
+   membership_tag, which constitutes a MAC over the message, under a key
+   derived from the group secrets.
+
+   The second form of authentication is that group members can verify a
+   message originated from a particular member of the group.  This is
+   guaranteed by a digital signature on each message from the sender's
+   signature key.
+
+   The signature keys held by group members are critical to the security
+   of MLS against active attacks.  If a member's signature key is
+   compromised, then an attacker can create LeafNodes and KeyPackages
+   impersonating the member; depending on the application, this can then
+   allow the attacker to join the group with the compromised member's
+   identity.  For example, if a group has enabled external parties to
+   join via external commits, then an attacker that has compromised a
+   member's signature key could use an external Commit to insert
+   themselves into the group -- even using a "resync"-style external
+   Commit to replace the compromised member in the group.
+
+   Applications can mitigate the risks of signature key compromise using
+   pre-shared keys.  If a group requires joiners to know a PSK in
+   addition to authenticating with a credential, then in order to mount
+   an impersonation attack, the attacker would need to compromise the
+   relevant PSK as well as the victim's signature key.  The cost of this
+   mitigation is that the application needs some external arrangement
+   that ensures that the legitimate members of the group have the
+   required PSKs.
+
+16.6.  Forward Secrecy and Post-Compromise Security
+
+   Forward secrecy and post-compromise security are important security
+   notions for long-lived MLS groups.  Forward secrecy means that
+   messages sent at a certain point in time are secure in the face of
+   later compromise of a group member.  Post-compromise security means
+   that messages are secure even if a group member was compromised at
+   some point in the past.
+
+                      Compromise
+                          |
+                          |
+                     |    V    |
+   ------------------|---------|------------------------->
+                     |         |                     Time
+   <-----------------|         |---------------->
+     Forward Secrecy |         | Post-Compromise
+                     |         |   Security
+
+          Figure 29: Forward Secrecy and Post-Compromise Security
+
+   Post-compromise security is provided between epochs by members
+   regularly updating their leaf key in the ratchet tree.  Updating
+   their leaf key prevents group secrets from continuing to be encrypted
+   to public keys whose private keys had previously been compromised.
+   Note that sending an Update proposal does not achieve PCS until
+   another member includes it in a Commit.  Members can achieve
+   immediate PCS by sending their own Commit and populating the path
+   field, as described in Section 12.4.  To be clear, in all these
+   cases, the PCS guarantees come into effect when the members of the
+   group process the relevant Commit, not when the sender creates it.
+
+   Forward secrecy between epochs is provided by deleting private keys
+   from past versions of the ratchet tree, as this prevents old group
+   secrets from being re-derived.  Forward secrecy _within_ an epoch is
+   provided by deleting message encryption keys once they've been used
+   to encrypt or decrypt a message.  Note that group secrets and message
+   encryption keys are shared by the group.  There is thus a risk to
+   forward secrecy as long as any member has not deleted these keys.
+   This is a particular risk if a member is offline for a long period of
+   time.  Applications SHOULD have mechanisms for evicting group members
+   that are offline for too long (i.e., have not changed their key
+   within some period).
+
+   New groups are also at risk of using previously compromised keys (as
+   with post-compromise security) if a member is added to a new group
+   via an old KeyPackage whose corresponding private key has been
+   compromised.  This risk can be mitigated by having clients regularly
+   generate new KeyPackages and upload them to the Delivery Service.
+   This way, the key material used to add a member to a new group is
+   more likely to be fresh and less likely to be compromised.
+
+16.7.  Uniqueness of Ratchet Tree Key Pairs
+
+   The encryption and signature keys stored in the encryption_key and
+   signature_key fields of ratchet tree nodes MUST be distinct from one
+   another.  If two members' leaf nodes have the same signature key, for
+   example, then the data origin authentication properties afforded by
+   signatures within the group are degraded.
+
+   Uniqueness of keys in leaf nodes is assured by explicitly checking
+   each leaf node as it is added to the tree, whether in an Add
+   proposal, in an Update proposal, or in the path field of a Commit.
+   Details can be found in Sections 7.3, 12.2, and 12.4.2.  Uniqueness
+   of encryption keys in parent nodes is assured by checking that the
+   keys in an UpdatePath are not found elsewhere in the tree (see
+   Section 12.4.2).
+
+16.8.  KeyPackage Reuse
+
+   KeyPackages are intended to be used only once.  That is, once a
+   KeyPackage has been used to introduce the corresponding client to a
+   group, it SHOULD be deleted from the KeyPackage publication system.
+   Reuse of KeyPackages can lead to replay attacks.
+
+   An application MAY allow for reuse of a "last resort" KeyPackage in
+   order to prevent denial-of-service attacks.  Since a KeyPackage is
+   needed to add a client to a new group, an attacker could prevent a
+   client from being added to new groups by exhausting all available
+   KeyPackages.  To prevent such a denial-of-service attack, the
+   KeyPackage publication system SHOULD rate-limit KeyPackage requests,
+   especially if not authenticated.
+
+16.9.  Delivery Service Compromise
+
+   MLS is designed to protect the confidentiality and integrity of the
+   group data even in the face of a compromised DS.  However, a
+   compromised DS can still mount some attacks.  While it cannot forge
+   messages, it can selectively delay or remove them.  In some cases,
+   this can be observed by detecting gaps in the per-sender generation
+   counter, though it may not always be possible to distinguish an
+   attack from message loss.  In addition, the DS can permanently block
+   messages to and from a group member.  This will not always be
+   detectable by other members.  If an application uses the DS to
+   resolve conflicts between simultaneous Commits (see Section 14), it
+   is also possible for the DS to influence which Commit is applied,
+   even to the point of preventing a member from ever having its Commits
+   applied.
+
+   When put together, these abilities potentially allow a DS to collude
+   with an attacker who has compromised a member's state to defeat PCS
+   by suppressing the valid Update and Commit messages from the member
+   that would lock out the attacker and update the member's leaf to a
+   new, uncompromised state.  Aside from the SenderData.generation
+   value, MLS leaves loss detection up to the application.
+
+16.10.  Authentication Service Compromise
+
+   Authentication Service compromise is much more serious than
+   compromise of the Delivery Service.  A compromised AS can assert a
+   binding for a signature key and identity pair of its choice, thus
+   allowing impersonation of a given user.  This ability is sufficient
+   to allow the AS to join new groups as if it were that user.
+   Depending on the application architecture, it may also be sufficient
+   to allow the compromised AS to join the group as an existing user,
+   for instance, as if it were a new device associated with the same
+   user.  If the application uses a transparency mechanism such as
+   CONIKS [CONIKS] or Key Transparency [KT], then it may be possible for
+   end users to detect this kind of misbehavior by the AS.  It is also
+   possible to construct schemes in which the various clients owned by a
+   user vouch for each other, e.g., by signing each others' keys.
+
+16.11.  Additional Policy Enforcement
+
+   The DS and AS may also apply additional policies to MLS operations to
+   obtain additional security properties.  For example, MLS enables any
+   participant to add or remove members of a group; a DS could enforce a
+   policy that only certain members are allowed to perform these
+   operations.  MLS authenticates all members of a group; a DS could
+   help ensure that only clients with certain types of credentials are
+   admitted.  MLS provides no inherent protection against denial of
+   service; a DS could also enforce rate limits in order to mitigate
+   these risks.
+
+16.12.  Group Fragmentation by Malicious Insiders
+
+   It is possible for a malicious member of a group to "fragment" the
+   group by crafting an invalid UpdatePath.  Recall that an UpdatePath
+   encrypts a sequence of path secrets to different subtrees of the
+   group's ratchet trees.  These path secrets should be derived in a
+   sequence as described in Section 7.4, but the UpdatePath syntax
+   allows the sender to encrypt arbitrary, unrelated secrets.  The
+   syntax also does not guarantee that the encrypted path secret for a
+   given node corresponds to the public key provided for that node.
+
+   Both of these types of corruption will cause processing of a Commit
+   to fail for some members of the group.  If the public key for a node
+   does not match the path secret, then the members that decrypt that
+   path secret will reject the Commit based on this mismatch.  If the
+   path secret sequence is incorrect at some point, then members that
+   can decrypt nodes before that point will compute a different public
+   key for the mismatched node than the one in the UpdatePath, which
+   also causes the Commit to fail.  Applications SHOULD provide
+   mechanisms for failed commits to be reported, so that group members
+   who were not able to recognize the error themselves can reinitialize
+   the group if necessary.
+
+   Even with such an error reporting mechanism in place, however, it is
+   still possible for members to get locked out of the group by a
+   malformed Commit.  Since malformed Commits can only be recognized by
+   certain members of the group, in an asynchronous application, it may
+   be the case that all members that could detect a fault in a Commit
+   are offline.  In such a case, the Commit will be accepted by the
+   group, and the resulting state will possibly be used as the basis for
+   further Commits.  When the affected members come back online, they
+   will reject the first Commit, and thus be unable to catch up with the
+   group.  These members will need to either add themselves back with an
+   external Commit or reinitialize the group from scratch.
+
+   Applications can address this risk by requiring certain members of
+   the group to acknowledge successful processing of a Commit before the
+   group regards the Commit as accepted.  The minimum set of
+   acknowledgements necessary to verify that a Commit is well-formed
+   comprises an acknowledgement from one member per node in the
+   UpdatePath, that is, one member from each subtree rooted in the
+   copath node corresponding to the node in the UpdatePath.  MLS does
+   not provide a built-in mechanism for such acknowledgements, but they
+   can be added at the application layer.
+
+17.  IANA Considerations
+
+   IANA has created the following registries:
+
+   *  MLS Cipher Suites (Section 17.1)
+
+   *  MLS Wire Formats (Section 17.2)
+
+   *  MLS Extension Types (Section 17.3)
+
+   *  MLS Proposal Types (Section 17.4)
+
+   *  MLS Credential Types (Section 17.5)
+
+   *  MLS Signature Labels (Section 17.6)
+
+   *  MLS Public Key Encryption Labels (Section 17.7)
+
+   *  MLS Exporter Labels (Section 17.8)
+
+   All of these registries are under the "Messaging Layer Security"
+   group registry heading, and assignments are made via the
+   Specification Required policy [RFC8126].  See Section 17.9 for
+   additional information about the MLS Designated Experts (DEs).
+
+17.1.  MLS Cipher Suites
+
+   A cipher suite is a combination of a protocol version and the set of
+   cryptographic algorithms that should be used.
+
+   Cipher suite names follow the naming convention:
+
+   CipherSuite MLS_LVL_KEM_AEAD_HASH_SIG = VALUE;
+
+   Where VALUE is represented as a 16-bit integer:
+
+   uint16 CipherSuite;
+
+             +===========+==================================+
+             | Component | Contents                         |
+             +===========+==================================+
+             | LVL       | The security level (in bits)     |
+             +-----------+----------------------------------+
+             | KEM       | The KEM algorithm used for HPKE  |
+             |           | in ratchet tree operations       |
+             +-----------+----------------------------------+
+             | AEAD      | The AEAD algorithm used for HPKE |
+             |           | and message protection           |
+             +-----------+----------------------------------+
+             | HASH      | The hash algorithm used for HPKE |
+             |           | and the MLS transcript hash      |
+             +-----------+----------------------------------+
+             | SIG       | The signature algorithm used for |
+             |           | message authentication           |
+             +-----------+----------------------------------+
+
+                                 Table 5
+
+   The columns in the registry are as follows:
+
+   *  Value: The numeric value of the cipher suite
+
+   *  Name: The name of the cipher suite
+
+   *  Recommended: Whether support for this cipher suite is recommended
+      by the IETF.  Valid values are "Y", "N", and "D", as described
+      below.  The default value of the "Recommended" column is "N".
+      Setting the Recommended item to "Y" or "D", or changing an item
+      whose current value is "Y" or "D", requires Standards Action
+      [RFC8126].
+
+      -  Y: Indicates that the IETF has consensus that the item is
+         RECOMMENDED.  This only means that the associated mechanism is
+         fit for the purpose for which it was defined.  Careful reading
+         of the documentation for the mechanism is necessary to
+         understand the applicability of that mechanism.  The IETF could
+         recommend mechanisms that have limited applicability, but it
+         will provide applicability statements that describe any
+         limitations of the mechanism or necessary constraints on its
+         use.
+
+      -  N: Indicates that the item has not been evaluated by the IETF
+         and that the IETF has made no statement about the suitability
+         of the associated mechanism.  This does not necessarily mean
+         that the mechanism is flawed, only that no consensus exists.
+         The IETF might have consensus to leave an item marked as "N" on
+         the basis of it having limited applicability or usage
+         constraints.
+
+      -  D: Indicates that the item is discouraged and SHOULD NOT or
+         MUST NOT be used.  This marking could be used to identify
+         mechanisms that might result in problems if they are used, such
+         as a weak cryptographic algorithm or a mechanism that might
+         cause interoperability problems in deployment.
+
+   *  Reference: The document where this cipher suite is defined
+
+   Initial contents:
+
+   +========+===================================================+=+====+
+   | Value  |Name                                               |R|Ref |
+   +========+===================================================+=+====+
+   | 0x0000 |RESERVED                                           |-|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x0001 |MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519       |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x0002 |MLS_128_DHKEMP256_AES128GCM_SHA256_P256            |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x0003 |MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519|Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x0004 |MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448           |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x0005 |MLS_256_DHKEMP521_AES256GCM_SHA512_P521            |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x0006 |MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448    |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x0007 |MLS_256_DHKEMP384_AES256GCM_SHA384_P384            |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x0A0A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x1A1A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x2A2A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x3A3A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x4A4A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x5A5A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x6A6A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x7A7A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x8A8A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0x9A9A |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0xAAAA |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0xBABA |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0xCACA |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0xDADA |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0xEAEA |GREASE                                             |Y|RFC |
+   |        |                                                   | |9420|
+   +--------+---------------------------------------------------+-+----+
+   | 0xF000 |Reserved for Private Use                           |-|RFC |
+   | -      |                                                   | |9420|
+   | 0xFFFF |                                                   | |    |
+   +--------+---------------------------------------------------+-+----+
+
+                   Table 6: MLS Extension Types Registry
+
+   All of the non-GREASE cipher suites use HMAC [RFC2104] as their MAC
+   function, with different hashes per cipher suite.  The mapping of
+   cipher suites to HPKE primitives [RFC9180], HMAC hash functions, and
+   TLS signature schemes [RFC8446] is as follows:
+
+    +======+======+========+========+========+========================+
+    |Value |KEM   | KDF    | AEAD   | Hash   | Signature              |
+    +======+======+========+========+========+========================+
+    |0x0001|0x0020| 0x0001 | 0x0001 | SHA256 | ed25519                |
+    +------+------+--------+--------+--------+------------------------+
+    |0x0002|0x0010| 0x0001 | 0x0001 | SHA256 | ecdsa_secp256r1_sha256 |
+    +------+------+--------+--------+--------+------------------------+
+    |0x0003|0x0020| 0x0001 | 0x0003 | SHA256 | ed25519                |
+    +------+------+--------+--------+--------+------------------------+
+    |0x0004|0x0021| 0x0003 | 0x0002 | SHA512 | ed448                  |
+    +------+------+--------+--------+--------+------------------------+
+    |0x0005|0x0012| 0x0003 | 0x0002 | SHA512 | ecdsa_secp521r1_sha512 |
+    +------+------+--------+--------+--------+------------------------+
+    |0x0006|0x0021| 0x0003 | 0x0003 | SHA512 | ed448                  |
+    +------+------+--------+--------+--------+------------------------+
+    |0x0007|0x0011| 0x0002 | 0x0002 | SHA384 | ecdsa_secp384r1_sha384 |
+    +------+------+--------+--------+--------+------------------------+
+
+                                  Table 7
+
+   The hash used for the MLS transcript hash is the one referenced in
+   the cipher suite name.  In the cipher suites defined above, "SHA256",
+   "SHA384", and "SHA512" refer, respectively, to the SHA-256, SHA-384,
+   and SHA-512 functions defined in [SHS].
+
+   In addition to the general requirements of Section 13.1, future
+   cipher suites MUST meet the requirements of Section 16.3.
+
+   It is advisable to keep the number of cipher suites low to increase
+   the likelihood that clients can interoperate in a federated
+   environment.  The cipher suites therefore include only modern, yet
+   well-established algorithms.  Depending on their requirements,
+   clients can choose between two security levels (roughly 128-bit and
+   256-bit).  Within the security levels, clients can choose between
+   faster X25519/X448 curves and curves compliant with FIPS 140-2 for
+   Diffie-Hellman key negotiations.  Clients may also choose
+   ChaCha20Poly1305 or AES-GCM, e.g., for performance reasons.  Since
+   ChaCha20Poly1305 is not listed by FIPS 140-2, it is not paired with
+   curves compliant with FIPS 140-2.  The security level of symmetric
+   encryption algorithms and hash functions is paired with the security
+   level of the curves.
+
+   The mandatory-to-implement cipher suite for MLS 1.0 is
+   MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519, which uses Curve25519
+   for key exchange, AES-128-GCM for HPKE, HKDF over SHA2-256, and
+   Ed25519 for signatures.  MLS clients MUST implement this cipher
+   suite.
+
+17.2.  MLS Wire Formats
+
+   The "MLS Wire Formats" registry lists identifiers for the types of
+   messages that can be sent in MLS.  The wire format field is two bytes
+   wide, so the valid wire format values are in the range 0x0000 to
+   0xFFFF.
+
+   Template:
+
+   *  Value: The numeric value of the wire format
+
+   *  Name: The name of the wire format
+
+   *  Recommended: Same as in Section 17.1
+
+   *  Reference: The document where this wire format is defined
+
+   Initial contents:
+
+       +=================+==========================+===+==========+
+       | Value           | Name                     | R | Ref      |
+       +=================+==========================+===+==========+
+       | 0x0000          | RESERVED                 | - | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x0001          | mls_public_message       | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x0002          | mls_private_message      | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x0003          | mls_welcome              | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x0004          | mls_group_info           | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x0005          | mls_key_package          | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0xF000 - 0xFFFF | Reserved for Private Use | - | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+
+                     Table 8: MLS Wire Formats Registry
+
+17.3.  MLS Extension Types
+
+   The "MLS Extension Types" registry lists identifiers for extensions
+   to the MLS protocol.  The extension type field is two bytes wide, so
+   valid extension type values are in the range 0x0000 to 0xFFFF.
+
+   Template:
+
+   *  Value: The numeric value of the extension type
+
+   *  Name: The name of the extension type
+
+   *  Message(s): The messages in which the extension may appear, drawn
+      from the following list:
+
+      -  KP: KeyPackage objects
+
+      -  LN: LeafNode objects
+
+      -  GC: GroupContext objects
+
+      -  GI: GroupInfo objects
+
+   *  Recommended: Same as in Section 17.1
+
+   *  Reference: The document where this extension is defined
+
+   Initial contents:
+
+     +==========+=======================+============+===+==========+
+     | Value    | Name                  | Message(s) | R | Ref      |
+     +==========+=======================+============+===+==========+
+     | 0x0000   | RESERVED              | N/A        | - | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x0001   | application_id        | LN         | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x0002   | ratchet_tree          | GI         | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x0003   | required_capabilities | GC         | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x0004   | external_pub          | GI         | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x0005   | external_senders      | GC         | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x0A0A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x1A1A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x2A2A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x3A3A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x4A4A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x5A5A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x6A6A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x7A7A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x8A8A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0x9A9A   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0xAAAA   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0xBABA   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0xCACA   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0xDADA   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0xEAEA   | GREASE                | KP, GI, LN | Y | RFC 9420 |
+     +----------+-----------------------+------------+---+----------+
+     | 0xF000 - | Reserved for Private  | N/A        | - | RFC 9420 |
+     | 0xFFFF   | Use                   |            |   |          |
+     +----------+-----------------------+------------+---+----------+
+
+                  Table 9: MLS Extension Types Registry
+
+17.4.  MLS Proposal Types
+
+   The "MLS Proposal Types" registry lists identifiers for types of
+   proposals that can be made for changes to an MLS group.  The
+   extension type field is two bytes wide, so valid extension type
+   values are in the range 0x0000 to 0xFFFF.
+
+   Template:
+
+   *  Value: The numeric value of the proposal type
+
+   *  Name: The name of the proposal type
+
+   *  Recommended: Same as in Section 17.1
+
+   *  External: Whether a proposal of this type may be sent by an
+      external sender (see Section 12.1.8)
+
+   *  Path Required: Whether a Commit covering a proposal of this type
+      is required to have its path field populated (see Section 12.4)
+
+   *  Reference: The document where this extension is defined
+
+   Initial contents:
+
+    +==========+==========================+===+=====+======+==========+
+    | Value    | Name                     | R | Ext | Path | Ref      |
+    +==========+==========================+===+=====+======+==========+
+    | 0x0000   | RESERVED                 | - | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x0001   | add                      | Y | Y   | N    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x0002   | update                   | Y | N   | Y    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x0003   | remove                   | Y | Y   | Y    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x0004   | psk                      | Y | Y   | N    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x0005   | reinit                   | Y | Y   | N    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x0006   | external_init            | Y | N   | Y    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x0007   | group_context_extensions | Y | Y   | Y    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x0A0A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x1A1A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x2A2A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x3A3A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x4A4A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x5A5A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x6A6A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x7A7A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x8A8A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0x9A9A   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0xAAAA   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0xBABA   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0xCACA   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0xDADA   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0xEAEA   | GREASE                   | Y | -   | -    | RFC 9420 |
+    +----------+--------------------------+---+-----+------+----------+
+    | 0xF000 - | Reserved for Private Use | - | -   | -    | RFC 9420 |
+    | 0xFFFF   |                          |   |     |      |          |
+    +----------+--------------------------+---+-----+------+----------+
+
+                   Table 10: MLS Proposal Types Registry
+
+17.5.  MLS Credential Types
+
+   The "MLS Credential Types" registry lists identifiers for types of
+   credentials that can be used for authentication in the MLS protocol.
+   The credential type field is two bytes wide, so valid credential type
+   values are in the range 0x0000 to 0xFFFF.
+
+   Template:
+
+   *  Value: The numeric value of the credential type
+
+   *  Name: The name of the credential type
+
+   *  Recommended: Same as in Section 17.1
+
+   *  Reference: The document where this credential is defined
+
+   Initial contents:
+
+       +=================+==========================+===+==========+
+       | Value           | Name                     | R | Ref      |
+       +=================+==========================+===+==========+
+       | 0x0000          | RESERVED                 | - | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x0001          | basic                    | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x0002          | x509                     | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x0A0A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x1A1A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x2A2A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x3A3A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x4A4A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x5A5A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x6A6A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x7A7A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x8A8A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0x9A9A          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0xAAAA          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0xBABA          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0xCACA          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0xDADA          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0xEAEA          | GREASE                   | Y | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+       | 0xF000 - 0xFFFF | Reserved for Private Use | - | RFC 9420 |
+       +-----------------+--------------------------+---+----------+
+
+                  Table 11: MLS Credential Types Registry
+
+17.6.  MLS Signature Labels
+
+   The SignWithLabel function defined in Section 5.1.2 avoids the risk
+   of confusion between signatures in different contexts.  Each context
+   is assigned a distinct label that is incorporated into the signature.
+   The "MLS Signature Labels" registry records the labels defined in
+   this document and allows additional labels to be registered in case
+   extensions add other types of signatures using the same signature
+   keys used elsewhere in MLS.
+
+   Template:
+
+   *  Label: The string to be used as the Label parameter to
+      SignWithLabel
+
+   *  Recommended: Same as in Section 17.1
+
+   *  Reference: The document where this label is defined
+
+   Initial contents:
+
+                   +====================+===+==========+
+                   | Label              | R | Ref      |
+                   +====================+===+==========+
+                   | "FramedContentTBS" | Y | RFC 9420 |
+                   +--------------------+---+----------+
+                   | "LeafNodeTBS"      | Y | RFC 9420 |
+                   +--------------------+---+----------+
+                   | "KeyPackageTBS"    | Y | RFC 9420 |
+                   +--------------------+---+----------+
+                   | "GroupInfoTBS"     | Y | RFC 9420 |
+                   +--------------------+---+----------+
+
+                       Table 12: MLS Signature Labels
+                                  Registry
+
+17.7.  MLS Public Key Encryption Labels
+
+   The EncryptWithLabel function defined in Section 5.1.3 avoids the
+   risk of confusion between ciphertexts produced for different purposes
+   in different contexts.  Each context is assigned a distinct label
+   that is incorporated into the signature.  The "MLS Public Key
+   Encryption Labels" registry records the labels defined in this
+   document and allows additional labels to be registered in case
+   extensions add other types of public key encryption using the same
+   HPKE keys used elsewhere in MLS.
+
+   Template:
+
+   *  Label: The string to be used as the Label parameter to
+      EncryptWithLabel
+
+   *  Recommended: Same as in Section 17.1
+
+   *  Reference: The document where this label is defined
+
+   Initial contents:
+
+                    +==================+===+==========+
+                    | Label            | R | Ref      |
+                    +==================+===+==========+
+                    | "UpdatePathNode" | Y | RFC 9420 |
+                    +------------------+---+----------+
+                    | "Welcome"        | Y | RFC 9420 |
+                    +------------------+---+----------+
+
+                          Table 13: MLS Public Key
+                         Encryption Labels Registry
+
+17.8.  MLS Exporter Labels
+
+   The exporter function defined in Section 8.5 allows applications to
+   derive key material from the MLS key schedule.  Like the TLS exporter
+   [RFC8446], the MLS exporter uses a label to distinguish between
+   different applications' use of the exporter.  The "MLS Exporter
+   Labels" registry allows applications to register their usage to avoid
+   collisions.
+
+   Template:
+
+   *  Label: The string to be used as the Label parameter to MLS-
+      Exporter
+
+   *  Recommended: Same as in Section 17.1
+
+   *  Reference: The document where this label is defined
+
+   The registry has no initial contents, since it is intended to be used
+   by applications, not the core protocol.  The table below is intended
+   only to show the column layout of the registry.
+
+                    +=======+=============+===========+
+                    | Label | Recommended | Reference |
+                    +=======+=============+===========+
+                    | (N/A) | (N/A)       | (N/A)     |
+                    +-------+-------------+-----------+
+
+                       Table 14: MLS Exporter Labels
+                                  Registry
+
+17.9.  MLS Designated Expert Pool
+
+   Specification Required [RFC8126] registry requests are registered
+   after a three-week review period on the MLS Designated Expert (DE)
+   mailing list <mailto:mls-reg-review@ietf.org> on the advice of one or
+   more of the MLS DEs.  However, to allow for the allocation of values
+   prior to publication, the MLS DEs may approve registration once they
+   are satisfied that such a specification will be published.
+
+   Registration requests sent to the MLS DEs' mailing list for review
+   SHOULD use an appropriate subject (e.g., "Request to register value
+   in MLS Bar registry").
+
+   Within the review period, the MLS DEs will either approve or deny the
+   registration request, communicating this decision to the MLS DEs'
+   mailing list and IANA.  Denials SHOULD include an explanation and, if
+   applicable, suggestions as to how to make the request successful.
+   Registration requests that are undetermined for a period longer than
+   21 days can be brought to the IESG's attention for resolution using
+   the <mailto:iesg@ietf.org> mailing list.
+
+   Criteria that SHOULD be applied by the MLS DEs includes determining
+   whether the proposed registration duplicates existing functionality,
+   whether it is likely to be of general applicability or useful only
+   for a single application, and whether the registration description is
+   clear.  For example, for cipher suite registrations, the MLS DEs will
+   apply the advisory found in Section 17.1.
+
+   IANA MUST only accept registry updates from the MLS DEs and SHOULD
+   direct all requests for registration to the MLS DEs' mailing list.
+
+   It is suggested that multiple MLS DEs who are able to represent the
+   perspectives of different applications using this specification be
+   appointed, in order to enable a broadly informed review of
+   registration decisions.  In cases where a registration decision could
+   be perceived as creating a conflict of interest for a particular MLS
+   DE, that MLS DE SHOULD defer to the judgment of the other MLS DEs.
+
+17.10.  The "message/mls" Media Type
+
+   This document registers the "message/mls" media type in the "message"
+   registry in order to allow other protocols (e.g., HTTP [RFC9113]) to
+   convey MLS messages.
+
+   Type name:  message
+
+   Subtype name:  mls
+
+   Required parameters:  none
+
+   Optional parameters:  version
+
+                         version:  The MLS protocol version expressed as
+         a string <major>.<minor>.  If omitted, the version is "1.0",
+         which corresponds to MLS ProtocolVersion mls10.  If for some
+         reason the version number in the media type parameter differs
+         from the ProtocolVersion embedded in the protocol, the protocol
+         takes precedence.
+
+   Encoding considerations:  MLS messages are represented using the TLS
+      presentation language [RFC8446].  Therefore, MLS messages need to
+      be treated as binary data.
+
+   Security considerations:  MLS is an encrypted messaging layer
+      designed to be transmitted over arbitrary lower-layer protocols.
+      The security considerations in this document (RFC 9420) also
+      apply.
+
+   Interoperability considerations:  N/A
+
+   Published specification:  RFC 9420
+
+   Applications that use this media type:  MLS-based messaging
+      applications
+
+   Fragment identifier considerations:  N/A
+
+   Additional information:
+
+      Deprecated alias names for this type:  N/A
+      Magic number(s):  N/A
+      File extension(s):  N/A
+      Macintosh file type code(s):  N/A
+
+   Person & email address to contact for further information:  IETF MLS
+      Working Group <mailto:mls@ietf.org>
+
+   Intended usage:  COMMON
+
+   Restrictions on usage:  N/A
+
+   Author:  IETF MLS Working Group
+
+   Change controller:  IETF
+
+18.  References
+
+18.1.  Normative References
+
+   [RFC2104]  Krawczyk, H., Bellare, M., and R. Canetti, "HMAC: Keyed-
+              Hashing for Message Authentication", RFC 2104,
+              DOI 10.17487/RFC2104, February 1997,
+              <https://www.rfc-editor.org/info/rfc2104>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8126]  Cotton, M., Leiba, B., and T. Narten, "Guidelines for
+              Writing an IANA Considerations Section in RFCs", BCP 26,
+              RFC 8126, DOI 10.17487/RFC8126, June 2017,
+              <https://www.rfc-editor.org/info/rfc8126>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC8446]  Rescorla, E., "The Transport Layer Security (TLS) Protocol
+              Version 1.3", RFC 8446, DOI 10.17487/RFC8446, August 2018,
+              <https://www.rfc-editor.org/info/rfc8446>.
+
+   [RFC9180]  Barnes, R., Bhargavan, K., Lipp, B., and C. Wood, "Hybrid
+              Public Key Encryption", RFC 9180, DOI 10.17487/RFC9180,
+              February 2022, <https://www.rfc-editor.org/info/rfc9180>.
+
+18.2.  Informative References
+
+   [ART]      Cohn-Gordon, K., Cremers, C., Garratt, L., Millican, J.,
+              and K. Milner, "On Ends-to-Ends Encryption: Asynchronous
+              Group Messaging with Strong Security Guarantees", Version
+              2.3, DOI 10.1145/3243734.3243747, March 2020,
+              <https://eprint.iacr.org/2017/666.pdf>.
+
+   [CFRG-AEAD-LIMITS]
+              Günther, F., Thomson, M., and C. A. Wood, "Usage Limits on
+              AEAD Algorithms", Work in Progress, Internet-Draft, draft-
+              irtf-cfrg-aead-limits-07, 31 May 2023,
+              <https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-
+              aead-limits-07>.
+
+   [CLINIC]   Miller, B., Huang, L., Joseph, A., and J. Tygar, "I Know
+              Why You Went to the Clinic: Risks and Realization of HTTPS
+              Traffic Analysis", Privacy Enhancing Technologies, pp.
+              143-163, DOI 10.1007/978-3-319-08506-7_8, 2014,
+              <https://doi.org/10.1007/978-3-319-08506-7_8>.
+
+   [CONIKS]   Melara, M. S., Blankstein, A., Bonneau, J., Felten, E. W.,
+              and M. J. Freedman, "CONIKS: Bringing Key Transparency to
+              End Users", Proceedings of the 24th USENIX Security
+              Symposium, ISBN 978-1-939133-11-3, August 2015,
+              <https://www.usenix.org/system/files/conference/
+              usenixsecurity15/sec15-paper-melara.pdf>.
+
+   [DoubleRatchet]
+              Cohn-Gordon, K., Cremers, C., Dowling, B., Garratt, L.,
+              and D. Stebila, "A Formal Security Analysis of the Signal
+              Messaging Protocol", 2017 IEEE European Symposium on
+              Security and Privacy (EuroS&P),
+              DOI 10.1109/eurosp.2017.27, April 2017,
+              <https://doi.org/10.1109/eurosp.2017.27>.
+
+   [HCJ16]    Husák, M., Čermák, M., Jirsík, T., and P. Čeleda, "HTTPS
+              traffic analysis and client identification using passive
+              SSL/TLS fingerprinting", EURASIP Journal on Information
+              Security, Vol. 2016, Issue 1,
+              DOI 10.1186/s13635-016-0030-7, February 2016,
+              <https://doi.org/10.1186/s13635-016-0030-7>.
+
+   [KT]       "Key Transparency Design Doc", commit fb0f87f, June 2020,
+              <https://github.com/google/keytransparency/blob/master/
+              docs/design.md>.
+
+   [MLS-ARCH] Beurdouche, B., Rescorla, E., Omara, E., Inguva, S., and
+              A. Duric, "The Messaging Layer Security (MLS)
+              Architecture", Work in Progress, Internet-Draft, draft-
+              ietf-mls-architecture-10, 16 December 2022,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-mls-
+              architecture-10>.
+
+   [NAN]      Bellare, M., Ng, R., and B. Tackmann, "Nonces Are Noticed:
+              AEAD Revisited", Advances in Cryptology - CRYPTO 2019, pp.
+              235-265, DOI 10.1007/978-3-030-26948-7_9, August 2019,
+              <https://doi.org/10.1007/978-3-030-26948-7_9>.
+
+   [RFC5116]  McGrew, D., "An Interface and Algorithms for Authenticated
+              Encryption", RFC 5116, DOI 10.17487/RFC5116, January 2008,
+              <https://www.rfc-editor.org/info/rfc5116>.
+
+   [RFC5905]  Mills, D., Martin, J., Ed., Burbank, J., and W. Kasch,
+              "Network Time Protocol Version 4: Protocol and Algorithms
+              Specification", RFC 5905, DOI 10.17487/RFC5905, June 2010,
+              <https://www.rfc-editor.org/info/rfc5905>.
+
+   [RFC6125]  Saint-Andre, P. and J. Hodges, "Representation and
+              Verification of Domain-Based Application Service Identity
+              within Internet Public Key Infrastructure Using X.509
+              (PKIX) Certificates in the Context of Transport Layer
+              Security (TLS)", RFC 6125, DOI 10.17487/RFC6125, March
+              2011, <https://www.rfc-editor.org/info/rfc6125>.
+
+   [RFC7696]  Housley, R., "Guidelines for Cryptographic Algorithm
+              Agility and Selecting Mandatory-to-Implement Algorithms",
+              BCP 201, RFC 7696, DOI 10.17487/RFC7696, November 2015,
+              <https://www.rfc-editor.org/info/rfc7696>.
+
+   [RFC8032]  Josefsson, S. and I. Liusvaara, "Edwards-Curve Digital
+              Signature Algorithm (EdDSA)", RFC 8032,
+              DOI 10.17487/RFC8032, January 2017,
+              <https://www.rfc-editor.org/info/rfc8032>.
+
+   [RFC8701]  Benjamin, D., "Applying Generate Random Extensions And
+              Sustain Extensibility (GREASE) to TLS Extensibility",
+              RFC 8701, DOI 10.17487/RFC8701, January 2020,
+              <https://www.rfc-editor.org/info/rfc8701>.
+
+   [RFC9000]  Iyengar, J., Ed. and M. Thomson, Ed., "QUIC: A UDP-Based
+              Multiplexed and Secure Transport", RFC 9000,
+              DOI 10.17487/RFC9000, May 2021,
+              <https://www.rfc-editor.org/info/rfc9000>.
+
+   [RFC9001]  Thomson, M., Ed. and S. Turner, Ed., "Using TLS to Secure
+              QUIC", RFC 9001, DOI 10.17487/RFC9001, May 2021,
+              <https://www.rfc-editor.org/info/rfc9001>.
+
+   [RFC9113]  Thomson, M., Ed. and C. Benfield, Ed., "HTTP/2", RFC 9113,
+              DOI 10.17487/RFC9113, June 2022,
+              <https://www.rfc-editor.org/info/rfc9113>.
+
+   [SHS]      National Institute of Standards and Technology (NIST),
+              "Secure Hash Standard (SHS)", FIPS PUB 180-4,
+              DOI 10.6028/NIST.FIPS.180-4, August 2015,
+              <https://doi.org/10.6028/NIST.FIPS.180-4>.
+
+   [Signal]   Perrin(ed), T. and M. Marlinspike, "The Double Ratchet
+              Algorithm", Revision 1, November 2016,
+              <https://www.signal.org/docs/specifications/
+              doubleratchet/>.
+
+Appendix A.  Protocol Origins of Example Trees
+
+   Protocol operations in MLS give rise to specific forms of ratchet
+   tree, typically affecting a whole direct path at once.  In this
+   section, we describe the protocol operations that could have given
+   rise to the various example trees in this document.
+
+   To construct the tree in Figure 11:
+
+   *  A creates a group with B, ..., G
+
+   *  F sends an empty Commit, setting X, Y, and W
+
+   *  G removes C and D, blanking V, U, and setting Y and W
+
+   *  B sends an empty Commit, setting T and W
+
+   To construct the tree in Figure 10:
+
+   *  A creates a group with B, ..., H, as well as some members outside
+      this subtree
+
+   *  F sends an empty Commit, setting Y and its ancestors
+
+   *  D removes B and C, with the following effects:
+
+      -  Blank the direct paths of B and C
+
+      -  Set X, the top node, and any further nodes in the direct path
+         of D
+
+   *  Someone outside this subtree removes G, blanking the direct path
+      of G
+
+   *  A adds a new member at B with a partial Commit, adding B as
+      unmerged at X
+
+   To construct the tree in Figure 13:
+
+   *  A creates a group with B, C, and D
+
+   *  B sends a full Commit, setting X and Y
+
+   *  D removes C, setting Z and Y
+
+   *  B adds a new member at C with a full Commit
+
+      -  The Add proposal adds C as unmerged at Z and Y
+
+      -  The path in the Commit resets X and Y, clearing Y's unmerged
+         leaves
+
+   To construct the tree in Figure 21:
+
+   *  A creates a group with B, ..., G
+
+   *  A removes F in a full Commit, setting T, U, and W
+
+   *  E sends an empty Commit, setting Y and W
+
+   *  A adds a new member at F in a partial Commit, adding F as unmerged
+      at Y and W
+
+Appendix B.  Evolution of Parent Hashes
+
+   To better understand how parent hashes are maintained, let's look in
+   detail at how they evolve in a small group.  Consider the following
+   sequence of operations:
+
+   1.  A initializes a new group
+
+   2.  A adds B to the group with a full Commit
+
+   3.  B adds C and D to the group with a full Commit
+
+   4.  C sends an empty Commit
+
+                             Y                   Y'
+                             |                   |
+                           .-+-.               .-+-.
+      ==>         ==>     /     \     ==>     /     \
+             X           X'      _=Z         X'      Z'
+            / \         / \     / \         / \     / \
+   A       A   B       A   B   C   D       A   B   C   D
+
+     Figure 30: Building a Four-Member Tree to Illustrate Parent Hashes
+
+   Then the parent hashes associated to the nodes will be updated as
+   follows (where we use the shorthand ph for parent hash, th for tree
+   hash, and osth for original sibling tree hash):
+
+   1.  A adds B: set X
+
+       *  A.parent_hash = ph(X) = H(X, ph="", osth=th(B))
+
+   2.  B adds C, D: set B', X', and Y
+
+       *  X'.parent_hash = ph(Y) = H(Y, ph="", osth=th(Z)), where th(Z)
+          covers (C, _, D)
+
+       *  B'.parent_hash = ph(X') = H(X', ph=X'.parent_hash, osth=th(A))
+
+   3.  C sends empty Commit: set C', Z', Y'
+
+       *  Z'.parent_hash = ph(Y') = H(Y', ph="", osth=th(X')), where
+          th(X') covers (A, X', B')
+
+       *  C'.parent_hash = ph(Z') = H(Z', ph=Z'.parent_hash, osth=th(D))
+
+   When a new member joins, they will receive a tree that has the
+   following parent hash values and compute the indicated parent hash
+   validity relationships:
+
+   +======+======================================+=====================+
+   | Node | Parent Hash Value                    | Valid?              |
+   +======+======================================+=====================+
+   | A    | H(X, ph="", osth=th(B))              | No, B changed       |
+   +------+--------------------------------------+---------------------+
+   | B'   | H(X', ph=X'.parent_hash, osth=th(A)) | Yes                 |
+   +------+--------------------------------------+---------------------+
+   | C'   | H(Z', ph=Z'.parent_hash, osth=th(D)) | Yes                 |
+   +------+--------------------------------------+---------------------+
+   | D    | (none, never sent an UpdatePath)     | N/A                 |
+   +------+--------------------------------------+---------------------+
+   | X'   | H(Y, ph="", osth=th(Z))              | No, Y and Z         |
+   |      |                                      | changed             |
+   +------+--------------------------------------+---------------------+
+   | Z'   | H(Y', ph="", osth=th(X'))            | Yes                 |
+   +------+--------------------------------------+---------------------+
+
+                                  Table 15
+
+   In other words, the joiner will find the following path-hash links in
+   the tree:
+
+          Y'
+          |
+          +-.
+             \
+      X'      Z'
+       \     /
+    A   B'  C'  D
+
+      Figure 31: Parent-hash links connect all non-empty parent nodes
+                                 to leaves
+
+   Since these chains collectively cover all non-blank parent nodes in
+   the tree, the tree is parent-hash valid.
+
+   Note that this tree, though valid, contains invalid parent-hash
+   links.  If a client were checking parent hashes top-down from Y', for
+   example, they would find that X' has an invalid parent hash relative
+   to Y', but that Z' has a valid parent hash.  Likewise, if the client
+   were checking bottom-up, they would find that the chain from B' ends
+   in an invalid link from X' to Y'.  These invalid links are the
+   natural result of multiple clients having committed.
+
+   Note also the way the tree hash and the parent hash interact.  The
+   parent hash of node C' includes the tree hash of node D.  The parent
+   hash of node Z' includes the tree hash of X', which covers nodes A
+   and B' (including the parent hash of B').  Although the tree hash and
+   the parent hash depend on each other, the dependency relationships
+   are structured so that there is never a circular dependency.
+
+   In the particular case where a new member first receives the tree for
+   a group (e.g., in a ratchet tree GroupInfo extension
+   Section 12.4.3.3), the parent hashes will be expressed in the tree
+   representation, but the tree hash need not be.  Instead, the new
+   member will recompute the tree hashes for all the nodes in the tree,
+   verifying that this matches the tree hash in the GroupInfo object.
+   If the tree is valid, then the subtree hashes computed in this way
+   will align with the inputs needed for parent hash validation (except
+   where recomputation is needed to account for unmerged leaves).
+
+Appendix C.  Array-Based Trees
+
+   One benefit of using complete balanced trees is that they admit a
+   simple flat array representation.  In this representation, leaf nodes
+   are even-numbered nodes, with the n-th leaf at 2*n.  Intermediate
+   nodes are held in odd-numbered nodes.  For example, the tree with 8
+   leaves has the following structure:
+
+                              X
+                              |
+                    .---------+---------.
+                   /                     \
+                  X                       X
+                  |                       |
+              .---+---.               .---+---.
+             /         \             /         \
+            X           X           X           X
+           / \         / \         / \         / \
+          /   \       /   \       /   \       /   \
+         X     X     X     X     X     X     X     X
+
+   Node: 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14
+
+   Leaf: 0     1     2     3     4     5     6     7
+
+          Figure 32: An Eight-Member Tree Represented as an Array
+
+   This allows us to compute relationships between tree nodes simply by
+   manipulating indices, rather than having to maintain complicated
+   structures in memory.  The basic rule is that the high-order bits of
+   parent and child nodes indices have the following relation (where x
+   is an arbitrary bit string):
+
+   parent=01x => left=00x, right=10x
+
+   Since node relationships are implicit, the algorithms for adding and
+   removing nodes at the right edge of the tree are quite simple.  If
+   there are N nodes in the array:
+
+   *  Add: Append N + 1 blank values to the end of the array.
+
+   *  Remove: Truncate the array to its first (N-1) / 2 entries.
+
+   The following python code demonstrates the tree computations
+   necessary to use an array-based tree for MLS.
+
+   # The exponent of the largest power of 2 less than x. Equivalent to:
+   #   int(math.floor(math.log(x, 2)))
+   def log2(x):
+       if x == 0:
+           return 0
+
+       k = 0
+       while (x >> k) > 0:
+           k += 1
+       return k-1
+
+   # The level of a node in the tree. Leaves are level 0, their parents
+   # are level 1, etc. If a node's children are at different levels,
+   # then its level is the max level of its children plus one.
+   def level(x):
+       if x & 0x01 == 0:
+           return 0
+
+       k = 0
+       while ((x >> k) & 0x01) == 1:
+           k += 1
+       return k
+
+   # The number of nodes needed to represent a tree with n leaves.
+   def node_width(n):
+       if n == 0:
+           return 0
+       else:
+           return 2*(n - 1) + 1
+
+   # The index of the root node of a tree with n leaves.
+   def root(n):
+       w = node_width(n)
+       return (1 << log2(w)) - 1
+
+   # The left child of an intermediate node.
+   def left(x):
+       k = level(x)
+       if k == 0:
+           raise Exception('leaf node has no children')
+
+       return x ^ (0x01 << (k - 1))
+
+   # The right child of an intermediate node.
+   def right(x):
+       k = level(x)
+       if k == 0:
+           raise Exception('leaf node has no children')
+
+       return x ^ (0x03 << (k - 1))
+
+   # The parent of a node.
+   def parent(x, n):
+       if x == root(n):
+           raise Exception('root node has no parent')
+
+       k = level(x)
+       b = (x >> (k + 1)) & 0x01
+       return (x | (1 << k)) ^ (b << (k + 1))
+
+   # The other child of the node's parent.
+   def sibling(x, n):
+       p = parent(x, n)
+       if x < p:
+           return right(p)
+       else:
+           return left(p)
+
+   # The direct path of a node, ordered from leaf to root.
+   def direct_path(x, n):
+       r = root(n)
+       if x == r:
+           return []
+
+       d = []
+       while x != r:
+           x = parent(x, n)
+           d.append(x)
+       return d
+
+   # The copath of a node, ordered from leaf to root.
+   def copath(x, n):
+       if x == root(n):
+           return []
+
+       d = direct_path(x, n)
+       d.insert(0, x)
+       d.pop()
+       return [sibling(y, n) for y in d]
+
+   # The common ancestor of two nodes is the lowest node that is in the
+   # direct paths of both leaves.
+   def common_ancestor_semantic(x, y, n):
+       dx = set([x]) | set(direct_path(x, n))
+       dy = set([y]) | set(direct_path(y, n))
+       dxy = dx & dy
+       if len(dxy) == 0:
+           raise Exception('failed to find common ancestor')
+
+       return min(dxy, key=level)
+
+   # The common ancestor of two nodes is the lowest node that is in the
+   # direct paths of both leaves.
+   def common_ancestor_direct(x, y, _):
+       # Handle cases where one is an ancestor of the other
+       lx, ly = level(x)+1, level(y)+1
+       if (lx <= ly) and (x>>ly == y>>ly):
+         return y
+       elif (ly <= lx) and (x>>lx == y>>lx):
+         return x
+
+       # Handle other cases
+       xn, yn = x, y
+       k = 0
+       while xn != yn:
+          xn, yn = xn >> 1, yn >> 1
+          k += 1
+       return (xn << k) + (1 << (k-1)) - 1
+
+Appendix D.  Link-Based Trees
+
+   An implementation may choose to store ratchet trees in a "link-based"
+   representation, where each node stores references to its parents and/
+   or children (as opposed to the array-based representation suggested
+   above, where these relationships are computed from relationships
+   between nodes' indices in the array).  Such an implementation needs
+   to update these links to maintain the balanced structure of the tree
+   as the tree is extended to add new members or truncated when members
+   are removed.
+
+   The following code snippet shows how these algorithms could be
+   implemented in Python.
+
+   class Node:
+       def __init__(self, value, left=None, right=None):
+           self.value = value    # Value of the node
+           self.left = left      # Left child node
+           self.right = right    # Right child node
+
+       @staticmethod
+       def blank_subtree(depth):
+           if depth == 1:
+               return Node(None)
+
+           L = Node.blank_subtree(depth-1)
+           R = Node.blank_subtree(depth-1)
+           return Node(None, left=L, right=R)
+
+       def empty(self):
+           L_empty = (self.left == None) or self.left.empty()
+           R_empty = (self.right == None) or self.right.empty()
+           return (self.value == None) and L_empty and R_empty
+
+   class Tree:
+       def __init__(self):
+           self.depth = 0    # Depth of the tree
+           self.root = None  # Root node of the tree, initially empty
+
+       # Add a blank subtree to the right
+       def extend(self):
+           if self.depth == 0:
+               self.depth = 1
+               self.root = Node(None)
+
+           L = self.root
+           R = Node.blank_subtree(self.depth)
+           self.root = Node(None, left=L, right=R)
+           self.depth += 1
+
+       # Truncate the right subtree
+       def truncate(self):
+           if self.root == None:
+               return
+
+           if not self.root.right.empty():
+               raise Exception("Cannot truncate non-blank subtree")
+
+           self.depth -= 1
+           self.root = self.root.left
+
+Contributors
+
+   Joel Alwen
+   Amazon
+   Email: alwenjo@amazon.com
+
+
+   Karthikeyan Bhargavan
+   Inria
+   Email: karthikeyan.bhargavan@inria.fr
+
+
+   Cas Cremers
+   CISPA
+   Email: cremers@cispa.de
+
+
+   Alan Duric
+   Wire
+   Email: alan@wire.com
+
+
+   Britta Hale
+   Naval Postgraduate School
+   Email: britta.hale@nps.edu
+
+
+   Srinivas Inguva
+   Email: singuva@yahoo.com
+
+
+   Konrad Kohbrok
+   Phoenix R&D
+   Email: konrad.kohbrok@datashrine.de
+
+
+   Albert Kwon
+   MIT
+   Email: kwonal@mit.edu
+
+
+   Tom Leavy
+   Amazon
+   Email: tomleavy@amazon.com
+
+
+   Brendan McMillion
+   Email: brendanmcmillion@gmail.com
+
+
+   Marta Mularczyk
+   Amazon
+   Email: mulmarta@amazon.com
+
+
+   Eric Rescorla
+   Mozilla
+   Email: ekr@rtfm.com
+
+
+   Michael Rosenberg
+   Trail of Bits
+   Email: michael.rosenberg@trailofbits.com
+
+
+   Théophile Wallez
+   Inria
+   Email: theophile.wallez@inria.fr
+
+
+   Thyla van der Merwe
+   Royal Holloway, University of London
+   Email: tjvdmerwe@gmail.com
+
+
+Authors' Addresses
+
+   Richard Barnes
+   Cisco
+   Email: rlb@ipv.sx
+
+
+   Benjamin Beurdouche
+   Inria & Mozilla
+   Email: ietf@beurdouche.com
+
+
+   Raphael Robert
+   Phoenix R&D
+   Email: ietf@raphaelrobert.com
+
+
+   Jon Millican
+   Meta Platforms
+   Email: jmillican@meta.com
+
+
+   Emad Omara
+   Email: emad.omara@gmail.com
+
+
+   Katriel Cohn-Gordon
+   University of Oxford
+   Email: me@katriel.co.uk

--- a/docs/mls/rfc9750.txt
+++ b/docs/mls/rfc9750.txt
@@ -1,0 +1,2355 @@
+﻿
+
+
+
+Internet Engineering Task Force (IETF)                     B. Beurdouche
+Request for Comments: 9750                               Inria & Mozilla
+Category: Informational                                      E. Rescorla
+ISSN: 2070-1721                                                         
+                                                                E. Omara
+                                                                        
+                                                               S. Inguva
+                                                                        
+                                                                A. Duric
+                                                              April 2025
+
+
+            The Messaging Layer Security (MLS) Architecture
+
+Abstract
+
+   The Messaging Layer Security (MLS) protocol (RFC 9420) provides a
+   group key agreement protocol for messaging applications.  MLS is
+   designed to protect against eavesdropping, tampering, and message
+   forgery, and to provide forward secrecy (FS) and post-compromise
+   security (PCS).
+
+   This document describes the architecture for using MLS in a general
+   secure group messaging infrastructure and defines the security goals
+   for MLS.  It provides guidance on building a group messaging system
+   and discusses security and privacy trade-offs offered by multiple
+   security mechanisms that are part of the MLS protocol (e.g.,
+   frequency of public encryption key rotation).  The document also
+   provides guidance for parts of the infrastructure that are not
+   standardized by MLS and are instead left to the application.
+
+   While the recommendations of this document are not mandatory to
+   follow in order to interoperate at the protocol level, they affect
+   the overall security guarantees that are achieved by a messaging
+   application.  This is especially true in the case of active
+   adversaries that are able to compromise clients, the Delivery Service
+   (DS), or the Authentication Service (AS).
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are candidates for any level of Internet
+   Standard; see Section 2 of RFC 7841.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   https://www.rfc-editor.org/info/rfc9750.
+
+Copyright Notice
+
+   Copyright (c) 2025 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Revised BSD License text as described in Section 4.e of the
+   Trust Legal Provisions and are provided without warranty as described
+   in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction
+   2.  General Setting
+     2.1.  Protocol Overview
+     2.2.  Abstract Services
+   3.  Overview of Operation
+     3.1.  Step 1: Account Creation
+     3.2.  Step 2: Initial Keying Material
+     3.3.  Step 3: Adding Bob to the Group
+     3.4.  Step 4: Adding Charlie to the Group
+     3.5.  Other Group Operations
+     3.6.  Proposals and Commits
+     3.7.  Users, Clients, and Groups
+   4.  Authentication Service
+   5.  Delivery Service
+     5.1.  Key Storage and Retrieval
+     5.2.  Delivery of Messages
+       5.2.1.  Strongly Consistent
+       5.2.2.  Eventually Consistent
+       5.2.3.  Welcome Messages
+     5.3.  Invalid Commits
+   6.  Functional Requirements
+     6.1.  Membership Changes
+     6.2.  Parallel Groups
+     6.3.  Asynchronous Usage
+     6.4.  Access Control
+     6.5.  Handling Authentication Failures
+     6.6.  Recovery After State Loss
+     6.7.  Support for Multiple Devices
+     6.8.  Extensibility
+     6.9.  Application Data Framing and Type Advertisements
+     6.10. Federation
+     6.11. Compatibility with Future Versions of MLS
+   7.  Operational Requirements
+   8.  Security and Privacy Considerations
+     8.1.  Assumptions on Transport Security Links
+       8.1.1.  Integrity and Authentication of Custom Metadata
+       8.1.2.  Metadata Protection for Unencrypted Group Operations
+       8.1.3.  DoS Protection
+       8.1.4.  Message Suppression and Error Correction
+     8.2.  Intended Security Guarantees
+       8.2.1.  Message Secrecy and Authentication
+       8.2.2.  Forward Secrecy and Post-Compromise Security
+       8.2.3.  Non-Repudiation vs. Deniability
+       8.2.4.  Associating a User's Clients
+     8.3.  Endpoint Compromise
+       8.3.1.  Compromise of Symmetric Keying Material
+       8.3.2.  Compromise by an Active Adversary with the Ability to
+               Sign Messages
+       8.3.3.  Compromise of Authentication with Access to a Signature
+               Key
+       8.3.4.  Security Considerations in the Context of a Full State
+               Compromise
+     8.4.  Service Node Compromise
+       8.4.1.  General Considerations
+       8.4.2.  Delivery Service Compromise
+       8.4.3.  Authentication Service Compromise
+     8.5.  Considerations for Attacks Outside of the Threat Model
+     8.6.  No Protection Against Replay by Insiders
+     8.7.  Cryptographic Analysis of the MLS Protocol
+   9.  IANA Considerations
+   10. References
+     10.1.  Normative References
+     10.2.  Informative References
+   Contributors
+   Authors' Addresses
+
+1.  Introduction
+
+   End-to-end security is used in the vast majority of instant messaging
+   systems and is also deployed in systems for other purposes such as
+   calling and conferencing.  In this context, "end-to-end" captures the
+   notion that users of the system enjoy some level of security -- with
+   the precise level depending on the system design -- even in the face
+   of malicious actions by the operator of the messaging system.
+
+   Messaging Layer Security (MLS) specifies an architecture (this
+   document) and a protocol [RFC9420] for providing end-to-end security
+   in this setting.  MLS is not intended as a full instant messaging
+   protocol but rather is intended to be embedded in concrete protocols,
+   such as the Extensible Messaging and Presence Protocol (XMPP)
+   [RFC6120].  Implementations of the MLS protocol will interoperate at
+   the cryptographic level, though they may have incompatibilities in
+   terms of how protected messages are delivered, contents of protected
+   messages, and identity/authentication infrastructures.  The MLS
+   protocol has been designed to provide the same security guarantees to
+   all users, for all group sizes, including groups of only two clients.
+
+2.  General Setting
+
+2.1.  Protocol Overview
+
+   MLS provides a way for _clients_ to form _groups_ within which they
+   can communicate securely.  For example, a set of users might use
+   clients on their phones or laptops to join a group and communicate
+   with each other.  A group may be as small as two clients (e.g., for
+   simple person-to-person messaging) or as large as hundreds of
+   thousands.  A client that is part of a group is a _member_ of that
+   group.  As groups change membership and group or member properties,
+   they advance from one _epoch_ to another and the cryptographic state
+   of the group evolves.
+
+   The group is represented as a tree, which represents the members as
+   the leaves of a tree.  It is used to efficiently encrypt to subsets
+   of the members.  Each member has a state called a _LeafNode_ object
+   holding the client's identity, credentials, and capabilities.
+
+   Various messages are used in the evolution from epoch to epoch.  A
+   _Proposal_ message proposes a change to be made in the next epoch,
+   such as adding or removing a member.  A _Commit_ message initiates a
+   new epoch by instructing members of the group to implement a
+   collection of proposals.  Proposals and Commits are collectively
+   called _handshake messages_. A _KeyPackage_ provides keys that can be
+   used to add the client to a group, including a public encryption key
+   and a signature key (both stored in the KeyPackage's LeafNode
+   object).  A _Welcome_ message provides a new member to the group with
+   the information to initialize their state for the epoch in which they
+   were added.
+
+   Of course most (but not all) applications use MLS to send encrypted
+   group messages.  An _application message_ is an MLS message with an
+   arbitrary application payload.
+
+   Finally, a _PublicMessage_ contains an integrity-protected MLS
+   handshake message, while a _PrivateMessage_ contains a confidential,
+   integrity-protected handshake or application message.
+
+   For a more detailed explanation of these terms, please consult the
+   MLS protocol specification [RFC9420].
+
+2.2.  Abstract Services
+
+   MLS is designed to operate within the context of a messaging service,
+   which may be a single service provider, a federated system, or some
+   kind of peer-to-peer system.  The service needs to provide two
+   services that facilitate client communication using MLS:
+
+   *  An Authentication Service (AS), which is responsible for attesting
+      to bindings between application-meaningful identifiers and the
+      public key material used for authentication in the MLS protocol.
+      The AS must also be able to generate credentials that encode these
+      bindings and validate credentials provided by MLS clients.
+
+   *  A Delivery Service (DS), which can receive and distribute messages
+      between group members.  In the case of group messaging, the DS may
+      also be responsible for acting as a "broadcaster" where the sender
+      sends a single message which is then forwarded to each recipient
+      in the group by the DS.  The DS is also responsible for storing
+      and delivering initial public key material required by MLS clients
+      in order to proceed with the group secret key establishment that
+      is part of the MLS protocol.
+
+   For presentation purposes, this document treats the AS and DS as
+   conventional network services.  However, MLS does not require a
+   specific implementation for the AS or DS.  These services may reside
+   on the same server or different servers, they may be distributed
+   between server and client components, and they may even involve some
+   action by users.  For example:
+
+   *  Several secure messaging services today provide a centralized DS
+      and rely on manual comparison of clients' public keys as the AS.
+
+   *  MLS clients connected to a peer-to-peer network could instantiate
+      a decentralized DS by transmitting MLS messages over that network.
+
+   *  In an MLS group using a Public Key Infrastructure (PKI) for
+      authentication, the AS would comprise the certificate issuance and
+      validation processes, both of which involve logic inside MLS
+      clients as well as various existing PKI roles (e.g., Certification
+      Authorities).
+
+   It is important to note that the AS can be completely abstract in the
+   case of a service provider which allows MLS clients to generate,
+   distribute, and validate credentials themselves.  As with the AS, the
+   DS can be completely abstract if users are able to distribute
+   credentials and messages without relying on a central DS (as in a
+   peer-to-peer system).  Note, though, that in such scenarios, clients
+   will need to implement logic that assures the delivery properties
+   required of the DS (see Section 5.2).
+
+   Figure 1 shows the relationship of these concepts, with three clients
+   and one group, and clients 2 and 3 being part of the group and client
+   1 not being part of any group.
+
+        +----------------+    +--------------+
+        | Authentication |    |   Delivery   |
+        |  Service (AS)  |    | Service (DS) |
+        +----------------+    +-------+------+
+                             /        |       \            Group
+                            / ........|........\................
+                           /  .       |         \              .
+                 +--------+-+ .  +----+-----+    +----------+  .
+                 | Client 1 | .  | Client 2 |    | Client 3 |  .
+                 +----------+ .  +----------+    +----------+  .
+                              .   Member 1        Member 2     .
+                              .                                .
+                              ..................................
+
+                  Figure 1: A Simplified Messaging System
+
+3.  Overview of Operation
+
+   Figure 2 shows the formation of an example group consisting of Alice,
+   Bob, and Charlie, with Alice driving the creation of the group.
+
+Alice     Bob       Charlie                     AS        DS
+
+Create account --------------------------------->               |
+<------------------------------------- Credential               |
+          Create account ----------------------->               | Step 1
+          <--------------------------- Credential               |
+                    Create account ------------->               |
+                    <----------------- Credential               |
+
+Initial Keying Material ----------------------------------->    |
+          Initial Keying Material ------------------------->    | Step 2
+                    Initial Keying Material --------------->    |
+
+Get Bob Initial Keying Material --------------------------->    |
+<------------------------------- Bob Initial Keying Material    |
+Add Bob to group ------------------------------------------>    | Step 3
+Welcome(Bob) ---------------------------------------------->    |
+          <-------------------------------- Add Bob to group    |
+          <------------------------------------ Welcome(Bob)    |
+
+Get Charlie Initial Keying Material ----------------------->    |
+<--------------------------- Charlie Initial Keying Material    |
+Add Charlie to group -------------------------------------->    |
+Welcome(Charlie) ------------------------------------------>    | Step 4
+          <---------------------------- Add Charlie to group    |
+                     <----------------- Add Charlie to group    |
+                     <--------------------- Welcome(Charlie)    |
+
+                  Figure 2: Group Formation Example
+
+   This process proceeds as follows.
+
+3.1.  Step 1: Account Creation
+
+   Alice, Bob, and Charlie create accounts with a service provider and
+   obtain credentials from the AS.  This is a one-time setup phase.
+
+3.2.  Step 2: Initial Keying Material
+
+   Alice, Bob, and Charlie authenticate to the DS and store some initial
+   keying material which is used to send encrypted messages to them for
+   the first time.  This keying material is authenticated with their
+   long-term credentials.  Although in principle this keying material
+   can be reused for multiple senders, in order to provide forward
+   secrecy it is better for this material to be regularly refreshed so
+   that each sender can use a new key and delete older keys.
+
+3.3.  Step 3: Adding Bob to the Group
+
+   When Alice wants to create a group including Bob, she first uses the
+   DS to look up his initial keying material.  She then generates two
+   messages:
+
+   *  A message to the entire group (which at this point is just her and
+      Bob) that adds Bob to the group.
+
+   *  A Welcome message just to Bob encrypted with his initial keying
+      material that includes the secret keying information necessary to
+      join the group.
+
+   She sends both of these messages to the DS, which is responsible for
+   sending them to the appropriate people.  Note that the security of
+   MLS does not depend on the DS forwarding the Welcome message only to
+   Bob, as it is encrypted for him; it is simply not necessary for other
+   group members to receive it.
+
+3.4.  Step 4: Adding Charlie to the Group
+
+   If Alice then wants to add Charlie to the group, she follows a
+   similar procedure as with Bob.  She first uses the DS to look up his
+   initial keying material and then generates two messages:
+
+   *  A message to the entire group (consisting of her, Bob, and
+      Charlie) adding Charlie to the group.
+
+   *  A Welcome message just to Charlie encrypted with his initial
+      keying material that includes the secret keying information
+      necessary to join the group.
+
+   At the completion of this process, we have a group with Alice, Bob,
+   and Charlie, which means that they share a single encryption key
+   which can be used to send messages or to key other protocols.
+
+3.5.  Other Group Operations
+
+   Once the group has been created, clients can perform other actions,
+   such as:
+
+   *  sending a message to everyone in the group
+
+   *  receiving a message from someone in the group
+
+   *  adding one or more clients to an existing group
+
+   *  removing one or more members from an existing group
+
+   *  updating their own key material
+
+   *  leaving a group (by asking to be removed)
+
+   Importantly, MLS does not itself enforce any access control on group
+   operations.  For instance, any member of the group can send a message
+   to add a new member or to evict an existing member.  This is in
+   contrast to some designs in which there is a single group controller
+   who can modify the group.  MLS-using applications are responsible for
+   setting their own access control policies.  For instance, if only the
+   group administrator is allowed to change group members, then it is
+   the responsibility of the application to inform members of this
+   policy and who the administrator is.
+
+3.6.  Proposals and Commits
+
+   The general pattern for any change in the group state (e.g., to add
+   or remove a user) is that it consists of two messages:
+
+   Proposal:  This message describes the change to be made (e.g., add
+      Bob to the group) but does not effect a change.
+
+   Commit:  This message changes the group state to include the changes
+      described in a set of proposals.
+
+   The simplest pattern is for a client to just send a Commit which
+   contains one or more Proposals.  For instance, Alice could send a
+   Commit with the Proposal Add(Bob) embedded to add Bob to the group.
+   However, there are situations in which one client might send a
+   Proposal and another might send the corresponding Commit.  For
+   instance, Bob might wish to remove himself from the group and send a
+   Remove proposal to do so (see Section 12.1.3 of [RFC9420]).  Because
+   Bob cannot send the Commit, an existing member must do so.  Commits
+   can apply to multiple valid Proposals, in which case all the listed
+   changes are applied.
+
+   It is also possible for a Commit to apply to an empty set of
+   Proposals, in which case it just updates the cryptographic state of
+   the group without changing its membership.
+
+3.7.  Users, Clients, and Groups
+
+   While it's natural to think of a messaging system as consisting of
+   groups of users, possibly using different devices, in MLS the basic
+   unit of operation is not the user but rather the "client".  Formally,
+   a client is a set of cryptographic objects composed of public values
+   such as a name (an identity), a public encryption key, and a public
+   signature key.  As usual, a user demonstrates ownership of the client
+   by demonstrating knowledge of the associated secret values.
+
+   In some messaging systems, clients belonging to the same user must
+   all share the same signature key pair, but MLS does not assume this;
+   instead, a user may have multiple clients with the same identity and
+   different keys.  In this case, each client will have its own
+   cryptographic state, and it is up to the application to determine how
+   to present this situation to users.  For instance, it may render
+   messages to and from a given user identically regardless of which
+   client they are associated with, or it may choose to distinguish
+   them.  It is also possible to have multiple clients associated with
+   the same user share state, as described in Section 8.2.4.
+
+   When a client is part of a group, it is called a member.  A group in
+   MLS is defined as the set of clients that have knowledge of the
+   shared group secret established in the group key establishment phase.
+   Note that until a client has been added to the group and contributed
+   to the group secret in a manner verifiable by other members of the
+   group, other members cannot assume that the client is a member of the
+   group; for instance, the newly added member might not have received
+   the Welcome message or been unable to decrypt it for some reason.
+
+4.  Authentication Service
+
+   The Authentication Service (AS) has to provide three services:
+
+   1.  Issue credentials to clients that attest to bindings between
+       identities and signature key pairs.
+
+   2.  Enable a client to verify that a credential presented by another
+       client is valid with respect to a reference identifier.
+
+   3.  Enable a group member to verify that a credential represents the
+       same client as another credential.
+
+   A member with a valid credential authenticates its MLS messages by
+   signing them with the private key corresponding to the public key
+   bound by its credential.
+
+   The AS is considered an abstract layer by the MLS specification; part
+   of this service could be, for instance, running on the members'
+   devices, while another part is a separate entity entirely.  The
+   following examples illustrate the breadth of this concept:
+
+   *  A PKI could be used as an AS [RFC5280].  The issuance function
+      would be provided by the certificate authorities in the PKI, and
+      the verification function would correspond to certificate
+      verification by clients.
+
+   *  Several current messaging applications rely on users verifying
+      each other's key fingerprints for authentication.  In this
+      scenario, the issuance function is simply the generation of a key
+      pair (i.e., a credential is just an identifier and public key,
+      with no information to assist in verification).  The verification
+      function is the application function that enables users to verify
+      keys.
+
+   *  In a system based on end-user Key Transparency (KT) [KT], the
+      issuance function would correspond to the insertion of a key in a
+      KT log under a user's identity.  The verification function would
+      correspond to verifying a key's inclusion in the log for a claimed
+      identity, together with the KT log's mechanisms for a user to
+      monitor and control which keys are associated with their identity.
+
+   By the nature of its role in MLS authentication, the AS is invested
+   with a large amount of trust and the compromise of the AS could allow
+   an adversary to, among other things, impersonate group members.  We
+   discuss security considerations regarding the compromise of the
+   different AS functions in detail in Section 8.4.3.
+
+   The association between members' identities and their signature keys
+   is fairly flexible in MLS.  As noted above, there is no requirement
+   that all clients belonging to a given user have the same signature
+   key (in fact, having duplicate signature keys in a group is
+   forbidden).  A member can also rotate the signature key they use
+   within a group.  These mechanisms allow clients to use different
+   signature keys in different contexts and at different points in time,
+   providing unlinkability and post-compromise security benefits.  Some
+   security trade-offs related to this flexibility are discussed in
+   Section 8.
+
+   In many applications, there are multiple MLS clients that represent a
+   single entity, such as a human user with a mobile and desktop version
+   of an application.  Often, the same set of clients is represented in
+   exactly the same list of groups.  In applications where this is the
+   intended situation, other clients can check that a user is
+   consistently represented by the same set of clients.  This would make
+   it more difficult for a malicious AS to issue fake credentials for a
+   particular user because clients would expect the credential to appear
+   in all groups of which the user is a member.  If a client credential
+   does not appear in all groups after some relatively short period of
+   time, clients have an indication that the credential might have been
+   created without the user's knowledge.  Due to the asynchronous nature
+   of MLS, however, there may be transient inconsistencies in a user's
+   client set, so correlating users' clients across groups is more of a
+   detection mechanism than a prevention mechanism.
+
+5.  Delivery Service
+
+   The Delivery Service (DS) plays two major roles in MLS:
+
+   *  As a directory service, providing the initial keying material for
+      clients to use.  This allows a client to establish a shared key
+      and send encrypted messages to other clients even if they're
+      offline.
+
+   *  Routing MLS messages among clients.
+
+   While MLS depends on correct behavior by the AS in order to provide
+   endpoint authentication and hence confidentiality of the group key,
+   these properties do not depend on correct behavior by the DS; even a
+   malicious DS cannot add itself to groups or recover the group key.
+   However, depending precisely on how MLS is used, the DS may be able
+   to determine group membership or prevent changes to the group from
+   taking place (e.g., by blocking group change messages).
+
+5.1.  Key Storage and Retrieval
+
+   Upon joining the system, each client stores its initial cryptographic
+   key material with the DS.  This key material, called a KeyPackage,
+   advertises the functional abilities of the client (e.g., supported
+   protocol versions, supported extensions, etc.) and the following
+   cryptographic information:
+
+   *  A credential from the AS attesting to the binding between the
+      identity and the client's signature key.
+
+   *  The client's asymmetric encryption public key.
+
+   All the parameters in the KeyPackage are signed with the signature
+   private key corresponding to the credential.  As noted in
+   Section 3.7, users may own multiple clients, each with their own
+   keying material.  Each KeyPackage is specific to an MLS version and
+   cipher suite, but a client may want to offer support for multiple
+   protocol versions and cipher suites.  As such, there may be multiple
+   KeyPackages stored by each user for a mix of protocol versions,
+   cipher suites, and end-user devices.
+
+   When a client wishes to establish a group or add clients to a group,
+   it first contacts the DS to request KeyPackages for each of the other
+   clients, authenticates the KeyPackages using the signature keys,
+   includes the KeyPackages in Add proposals, and encrypts the
+   information needed to join the group (the _GroupInfo_ object) with an
+   ephemeral key; it then separately encrypts the ephemeral key with the
+   public encryption key (init_key) from each KeyPackage.  When a client
+   requests a KeyPackage in order to add a user to a group, the DS
+   should provide the minimum number of KeyPackages necessary to satisfy
+   the request.  For example, if the request specifies the MLS version,
+   the DS might provide one KeyPackage per supported cipher suite, even
+   if it has multiple such KeyPackages to enable the corresponding
+   client to be added to multiple groups before needing to upload more
+   fresh KeyPackages.
+
+   In order to avoid replay attacks and provide forward secrecy for
+   messages sent using the initial keying material, KeyPackages are
+   intended to be used only once, and init_key is intended to be deleted
+   by the client after decryption of the Welcome message.  The DS is
+   responsible for ensuring that each KeyPackage is only used to add its
+   client to a single group, with the possible exception of a "last
+   resort" KeyPackage that is specially designated by the client to be
+   used multiple times.  Clients are responsible for providing new
+   KeyPackages as necessary in order to minimize the chance that the
+   "last resort" KeyPackage will be used.
+
+      *Recommendation:* Ensure that "last resort" KeyPackages don't get
+      used by provisioning enough standard KeyPackages.
+
+      *Recommendation:* Rotate "last resort" KeyPackages as soon as
+      possible after being used or if they have been stored for a
+      prolonged period of time.  Overall, avoid reusing "last resort"
+      KeyPackages as much as possible.
+
+      *Recommendation:* Ensure that the client for which a "last resort"
+      KeyPackage has been used is updating leaf keys as early as
+      possible.
+
+      *Recommendation:* Ensure that clients delete the private component
+      of their init_key after processing a Welcome message, or after the
+      rotation of the "last resort" KeyPackage.
+
+   Overall, it needs to be noted that key packages need to be updated
+   when signature keys are changed.
+
+5.2.  Delivery of Messages
+
+   The main responsibility of the DS is to ensure delivery of messages.
+   Some MLS messages need only be delivered to specific clients (e.g., a
+   Welcome message initializing a new member's state), while others need
+   to be delivered to all the members of a group.  The DS may enable the
+   latter delivery pattern via unicast channels (sometimes known as
+   "client fanout"), broadcast channels ("server fanout"), or a mix of
+   both.
+
+   For the most part, MLS does not require the DS to deliver messages in
+   any particular order.  Applications can set policies that control
+   their tolerance for out-of-order messages (see Section 7), and
+   messages that arrive significantly out of order can be dropped
+   without otherwise affecting the protocol.  There are two exceptions
+   to this.  First, Proposal messages should all arrive before the
+   Commit that references them.  Second, because an MLS group has a
+   linear history of epochs, the members of the group must agree on the
+   order in which changes are applied.  Concretely, the group must agree
+   on a single MLS Commit message that ends each epoch and begins the
+   next one.
+
+   In practice, there's a realistic risk of two members generating
+   Commit messages at the same time, based on the same epoch, and both
+   attempting to send them to the group at the same time.  The extent to
+   which this is a problem, and the appropriate solution, depend on the
+   design of the DS.  Per the CAP theorem [CAPBR], there are two general
+   classes of distributed systems that the DS might fall into:
+
+   *  Consistent and Partition-tolerant, or Strongly Consistent,
+      systems, which can provide a globally consistent view of data but
+      have the inconvenience of clients needing to handle rejected
+      messages.
+
+   *  Available and Partition-tolerant, or Eventually Consistent,
+      systems, which continue working despite network issues but may
+      return different views of data to different users.
+
+   Strategies for sequencing messages in strongly and eventually
+   consistent systems are described in the next two subsections.  Most
+   DSs will use the strongly consistent paradigm, but this remains a
+   choice that can be handled in coordination with the client and
+   advertised in the KeyPackages.
+
+   However, note that a malicious DS could also reorder messages or
+   provide an inconsistent view to different users.  The "generation"
+   counter in MLS messages provides per-sender loss detection and
+   ordering that cannot be manipulated by the DS, but this does not
+   provide complete protection against partitioning.  A DS can cause a
+   partition in the group by partitioning key exchange messages; this
+   can be detected only by out-of-band comparison (e.g., confirming that
+   all clients have the same epoch_authenticator value).  A mechanism
+   for more robust protections is discussed in [EXTENSIONS].
+
+   Other forms of DS misbehavior are still possible that are not easy to
+   detect.  For instance, a DS can simply refuse to relay messages to
+   and from a given client.  Without some sort of side information,
+   other clients cannot generally detect this form of Denial-of-Service
+   (DoS) attack.
+
+5.2.1.  Strongly Consistent
+
+   With this approach, the DS ensures that some types of incoming
+   messages have a linear order and all members agree on that order.
+   The Delivery Service is trusted to break ties when two members send a
+   Commit message at the same time.
+
+   As an example, there could be an "ordering server" DS that broadcasts
+   all messages received to all users and ensures that all clients see
+   messages in the same order.  This would allow clients to only apply
+   the first valid Commit for an epoch and ignore subsequent Commits.
+   Clients that send a Commit would then wait to apply it until it is
+   broadcast back to them by the Delivery Service, assuming that they do
+   not receive another Commit first.
+
+   Alternatively, the DS can rely on the epoch and content_type fields
+   of an MLSMessage to provide an order only to handshake messages, and
+   possibly even filter or reject redundant Commit messages proactively
+   to prevent them from being broadcast.  There is some risk associated
+   with filtering; this is discussed further in Section 5.3.
+
+5.2.2.  Eventually Consistent
+
+   With this approach, the DS is built in a way that may be
+   significantly more available or performant than a strongly consistent
+   system, but where it offers weaker consistency guarantees.  Messages
+   may arrive to different clients in different orders and with varying
+   amounts of latency, which means clients are responsible for
+   reconciliation.
+
+   This type of DS might arise, for example, when group members are
+   sending each message to each other member individually or when a
+   distributed peer-to-peer network is used to broadcast messages.
+
+   Upon receiving a Commit from the DS, clients can either:
+
+   1.  Pause sending new messages for a short amount of time to account
+       for a reasonable degree of network latency and see if any other
+       Commits are received for the same epoch.  If multiple Commits are
+       received, the clients can use a deterministic tie-breaking policy
+       to decide which to accept, and then resume sending messages as
+       normal.
+
+   2.  Accept the Commit immediately but keep a copy of the previous
+       group state for a short period of time.  If another Commit for a
+       past epoch is received, clients use a deterministic tie-breaking
+       policy to decide if they should continue using the Commit they
+       originally accepted or revert and use the later one.  Note that
+       any copies of previous or forked group states must be deleted
+       within a reasonable amount of time to ensure that the protocol
+       provides forward secrecy.
+
+   If the Commit references an unknown proposal, group members may need
+   to solicit the DS or other group members individually for the
+   contents of the proposal.
+
+5.2.3.  Welcome Messages
+
+   Whenever a commit adds new members to a group, MLS requires the
+   committer to send a Welcome message to the new members.  Applications
+   should ensure that Welcome messages are coupled with the tie-breaking
+   logic for commits (see Sections 5.2.1 and 5.2.2).  That is, when
+   multiple commits are sent for the same epoch, applications need to
+   ensure that only Welcome messages corresponding to the commit that
+   "succeeded" are processed by new members.
+
+   This is particularly important when groups are being reinitialized.
+   When a group is reinitialized, it is restarted with a different
+   protocol version and/or cipher suite but identical membership.
+   Whenever an authorized member sends and commits a ReInit proposal,
+   this immediately freezes the existing group and triggers the creation
+   of a new group with a new group_id.
+
+   Ideally, the new group would be created by the same member that
+   committed the ReInit proposal (including sending Welcome messages for
+   the new group to all of the previous group's members).  However, this
+   operation is not always atomic, so it's possible for a member to go
+   offline after committing a ReInit proposal but before creating the
+   new group.  If this happens, it's necessary for another member to
+   continue the reinitialization by creating the new group and sending
+   out Welcome messages.
+
+   This has the potential to create a race condition, where multiple
+   members try to continue the reinitialization at the same time, and
+   members receive multiple Welcome messages for each attempt at
+   reinitializing the same group.  Ensuring that all members agree on
+   which reinitialization attempt is "correct" is key to prevent this
+   from causing forks.
+
+5.3.  Invalid Commits
+
+   Situations can arise where a malicious or buggy client sends a Commit
+   that is not accepted by all members of the group, and the DS is not
+   able to detect this and reject the Commit.  For example, a buggy
+   client might send an encrypted Commit with an invalid set of
+   proposals, or a malicious client might send a malformed Commit of the
+   form described in Section 16.12 of [RFC9420].
+
+   In situations where the DS is attempting to filter redundant Commits,
+   the DS might update its internal state under the assumption that a
+   Commit has succeeded and thus end up in a state inconsistent with the
+   members of the group.  For example, the DS might think that the
+   current epoch is now n+1 and reject any commits from other epochs,
+   while the members think the epoch is n, and as a result, the group is
+   stuck -- no member can send a Commit that the DS will accept.
+
+   Such "desynchronization" problems can arise even when the DS takes no
+   stance on which Commit is "correct" for an epoch.  The DS can enable
+   clients to choose between Commits, for example by providing Commits
+   in the order received and allowing clients to reject any Commits that
+   violate their view of the group's policies.  As such, all honest and
+   correctly implemented clients will arrive at the same "first valid
+   Commit" and choose to process it.  Malicious or buggy clients that
+   process a different Commit will end up in a forked view of the group.
+
+   When these desynchronizations happen, the application may choose to
+   take action to restore the functionality of the group.  These actions
+   themselves can have security implications.  For example, a client
+   developer might have a client automatically rejoin a group, using an
+   external join, when it processes an invalid Commit.  In this
+   operation, however, the client trusts that the GroupInfo provided by
+   the DS faithfully represents the state of the group, and not, say, an
+   earlier state containing a compromised leaf node.  In addition, the
+   DS may be able to trigger this condition by deliberately sending the
+   victim an invalid Commit.  In certain scenarios, this trust can
+   enable the DS or a malicious insider to undermine the post-compromise
+   security guarantees provided by MLS.
+
+   Actions to recover from desynchronization can also have availability
+   and DoS implications.  For example, if a recovery mechanism relies on
+   external joins, a malicious member that deliberately posts an invalid
+   Commit could also post a corrupted GroupInfo object in order to
+   prevent victims from rejoining the group.  Thus, careful analysis of
+   security implications should be made for any system for recovering
+   from desynchronization.
+
+6.  Functional Requirements
+
+   MLS is designed as a large-scale group messaging protocol and hence
+   aims to provide both performance and security (e.g., integrity and
+   confidentiality) to its users.  Messaging systems that implement MLS
+   provide support for conversations involving two or more members, and
+   aim to scale to groups with tens of thousands of members, typically
+   including many users using multiple devices.
+
+6.1.  Membership Changes
+
+   MLS aims to provide agreement on group membership, meaning that all
+   group members have agreed on the list of current group members.
+
+   Some applications may wish to enforce Access Control Lists (ACLs) to
+   limit addition or removal of group members to privileged clients or
+   users.  Others may wish to require authorization from the current
+   group members or a subset thereof.  Such policies can be implemented
+   at the application layer, on top of MLS.  Regardless, MLS does not
+   allow for or support addition or removal of group members without
+   informing all other members.
+
+   Membership of an MLS group is managed at the level of individual
+   clients.  In most cases, a client corresponds to a specific device
+   used by a user.  If a user has multiple devices, the user will
+   generally be represented in a group by multiple clients (although
+   applications could choose to have devices share keying material).  If
+   an application wishes to implement operations at the level of users,
+   it is up to the application to track which clients belong to a given
+   user and ensure that they are added/removed consistently.
+
+   MLS provides two mechanisms for changing the membership of a group.
+   The primary mechanism is for an authorized member of the group to
+   send a Commit that adds or removes other members.  A secondary
+   mechanism is an "external join": A member of the group publishes
+   certain information about the group, which a new member can use to
+   construct an "external" Commit message that adds the new member to
+   the group.  (There is no similarly unilateral way for a member to
+   leave the group; they must be removed by a remaining member.)
+
+   With both mechanisms, changes to the membership are initiated from
+   inside the group.  When members perform changes directly, this is
+   clearly the case.  External joins are authorized indirectly, in the
+   sense that a member publishing a GroupInfo object authorizes anyone
+   to join who has access to the GroupInfo object, subject to whatever
+   access control policies the application applies for external joins.
+
+   Both types of joins are done via a Commit message, which could be
+   blocked by the DS or rejected by clients if the join is not
+   authorized.  The former approach requires that Commits be visible to
+   the DS; the latter approach requires that clients all share a
+   consistent policy.  In the unfortunate event that an unauthorized
+   member is able to join, MLS enables any member to remove them.
+
+   Application setup may also determine other criteria for membership
+   validity.  For example, per-device signature keys can be signed by an
+   identity key recognized by other participants.  If a certificate
+   chain is used to authenticate device signature keys, then revocation
+   by the owner adds an alternative mechanism to prompt membership
+   removal.
+
+   An MLS group's secrets change on every change of membership, so each
+   client only has access to the secrets used by the group while they
+   are a member.  Messages sent before a client joins or after they are
+   removed are protected with keys that are not accessible to the
+   client.  Compromise of a member removed from a group does not affect
+   the security of messages sent after their removal.  Messages sent
+   during the client's membership are also secure as long as the client
+   has properly implemented the MLS deletion schedule, which calls for
+   the secrets used to encrypt or decrypt a message to be deleted after
+   use, along with any secrets that could be used to derive them.
+
+6.2.  Parallel Groups
+
+   Any user or client may have membership in several groups
+   simultaneously.  The set of members of any group may or may not
+   overlap with the members of another group.  MLS guarantees that the
+   FS and PCS goals within a given group are maintained and not weakened
+   by user membership in multiple groups.  However, actions in other
+   groups likewise do not strengthen the FS and PCS guarantees within a
+   given group, e.g., key updates within a given group following a
+   device compromise do not provide PCS healing in other groups; each
+   group must be updated separately to achieve these security
+   objectives.  This also applies to future groups that a member has yet
+   to join, which are likewise unaffected by updates performed in
+   current groups.
+
+   Applications can strengthen connectivity among parallel groups by
+   requiring periodic key updates from a user across all groups in which
+   they have membership.
+
+   MLS provides a pre-shared key (PSK) mechanism that can be used to
+   link healing properties among parallel groups.  For example, suppose
+   a common member M of two groups A and B has performed a key update in
+   group A but not in group B.  The key update provides PCS with regard
+   to M in group A.  If a PSK is exported from group A and injected into
+   group B, then some of these PCS properties carry over to group B,
+   since the PSK and secrets derived from it are only known to the new,
+   updated version of M, not to the old, possibly compromised version of
+   M.
+
+6.3.  Asynchronous Usage
+
+   No operation in MLS requires two distinct clients or members to be
+   online simultaneously.  In particular, members participating in
+   conversations protected using MLS can update the group's keys, add or
+   remove new members, and send messages without waiting for another
+   user's reply.
+
+   Messaging systems that implement MLS have to provide a transport
+   layer for delivering messages asynchronously and reliably.
+
+6.4.  Access Control
+
+   Because all clients within a group (members) have access to the
+   shared cryptographic material, the MLS protocol allows each member of
+   the messaging group to perform operations.  However, every service/
+   infrastructure has control over policies applied to its own clients.
+   Applications managing MLS clients can be configured to allow for
+   specific group operations.  On the one hand, an application could
+   decide that a group administrator will be the only member to perform
+   Add and Remove operations.  On the other hand, in many settings such
+   as open discussion forums, joining can be allowed for anyone.
+
+   While MLS application messages are always encrypted, MLS handshake
+   messages can be sent either encrypted (in an MLS PrivateMessage) or
+   unencrypted (in an MLS PublicMessage).  Applications may be designed
+   such that intermediaries need to see handshake messages, for example
+   to enforce policy on which commits are allowed, or to provide MLS
+   ratchet tree data in a central location.  If handshake messages are
+   unencrypted, it is especially important that they be sent over a
+   channel with strong transport encryption (see Section 8) in order to
+   prevent external attackers from monitoring the status of the group.
+   Applications that use unencrypted handshake messages may take
+   additional steps to reduce the amount of metadata that is exposed to
+   the intermediary.  Everything else being equal, using encrypted
+   handshake messages provides stronger privacy properties than using
+   unencrypted handshake messages, as it prevents intermediaries from
+   learning about the structure of the group.
+
+   If handshake messages are encrypted, any access control policies must
+   be applied at the client, so the application must ensure that the
+   access control policies are consistent across all clients to make
+   sure that they remain in sync.  If two different policies were
+   applied, the clients might not accept or reject a group operation and
+   end up in different cryptographic states, breaking their ability to
+   communicate.
+
+      *Recommendation:* Avoid using inconsistent access control
+      policies, especially when using encrypted group operations.
+
+   MLS allows actors outside the group to influence the group in two
+   ways: External signers can submit proposals for changes to the group,
+   and new joiners can use an external join to add themselves to the
+   group.  The external_senders extension ensures that all members agree
+   on which signers are allowed to send proposals, but any other
+   policies must be assured to be consistent, as noted above.
+
+      *Recommendation:* Have an explicit group policy setting the
+      conditions under which external joins are allowed.
+
+6.5.  Handling Authentication Failures
+
+   Within an MLS group, every member is authenticated to every other
+   member by means of credentials issued and verified by the AS.  MLS
+   does not prescribe what actions, if any, an application should take
+   in the event that a group member presents an invalid credential.  For
+   example, an application may require such a member to be immediately
+   evicted or may allow some grace period for the problem to be
+   remediated.  To avoid operational problems, it is important for all
+   clients in a group to have a consistent view of which credentials in
+   a group are valid, and how to respond to invalid credentials.
+
+      *Recommendation:* Have a uniform credential validation process to
+      ensure that all group members evaluate other members' credentials
+      in the same way.
+
+      *Recommendation:* Have a uniform policy for how invalid
+      credentials are handled.
+
+   In some authentication systems, it is possible for a previously valid
+   credential to become invalid over time.  For example, in a system
+   based on X.509 certificates, credentials can expire or be revoked.
+   The MLS update mechanisms allow a client to replace an old credential
+   with a new one.  This is best done before the old credential becomes
+   invalid.
+
+      *Recommendation:* Proactively rotate credentials, especially if a
+      credential is about to become invalid.
+
+6.6.  Recovery After State Loss
+
+   Group members whose local MLS state is lost or corrupted can
+   reinitialize their state by rejoining the group as a new member and
+   removing the member representing their earlier state.  An application
+   can require that a client performing such a reinitialization prove
+   its prior membership with a PSK that was exported from the previous
+   state.
+
+   There are a few practical challenges to this approach.  For example,
+   the application will need to ensure that all members have the
+   required PSK, including any new members that have joined the group
+   since the epoch in which the PSK was issued.  And of course, if the
+   PSK is lost or corrupted along with the member's other state, then it
+   cannot be used to recover.
+
+   Reinitializing in this way does not provide the member with access to
+   group messages exchanged during the state loss window, but enables
+   proof of prior membership in the group.  Applications may choose
+   various configurations for providing lost messages to valid group
+   members that are able to prove prior membership.
+
+6.7.  Support for Multiple Devices
+
+   It is common for users within a group to own multiple devices.  A new
+   device can be added to a group and be considered as a new client by
+   the protocol.  This client will not gain access to the history even
+   if it is owned by someone who owns another member of the group.  MLS
+   does not provide direct support for restoring history in this case,
+   but applications can elect to provide such a mechanism outside of
+   MLS.  Such mechanisms, if used, may reduce the FS and PCS guarantees
+   provided by MLS.
+
+6.8.  Extensibility
+
+   The MLS protocol provides several extension points where additional
+   information can be provided.  Extensions to KeyPackages allow clients
+   to disclose additional information about their capabilities.  Groups
+   can also have extension data associated with them, and the group
+   agreement properties of MLS will confirm that all members of the
+   group agree on the content of these extensions.
+
+6.9.  Application Data Framing and Type Advertisements
+
+   Application messages carried by MLS are opaque to the protocol and
+   can contain arbitrary data.  Each application that uses MLS needs to
+   define the format of its application_data and any mechanism necessary
+   to determine the format of that content over the lifetime of an MLS
+   group.  In many applications, this means managing format migrations
+   for groups with multiple members who may each be offline at
+   unpredictable times.
+
+      *Recommendation:* Use the content mechanism defined in
+      [EXTENSIONS], unless the specific application defines another
+      mechanism that more appropriately addresses the same requirements
+      for that application of MLS.
+
+   The MLS framing for application messages also provides a field where
+   clients can send information that is authenticated but not encrypted.
+   Such information can be used by servers that handle the message, but
+   group members are assured that it has not been tampered with.
+
+6.10.  Federation
+
+   The protocol aims to be compatible with federated environments.
+   While this document does not specify all necessary mechanisms
+   required for federation, multiple MLS implementations can
+   interoperate to form federated systems if they use compatible
+   authentication mechanisms, cipher suites, application content, and
+   infrastructure functionalities.  Federation is described in more
+   detail in [FEDERATION].
+
+6.11.  Compatibility with Future Versions of MLS
+
+   It is important that multiple versions of MLS be able to coexist in
+   the future.  Thus, MLS offers a version negotiation mechanism; this
+   mechanism prevents version downgrade attacks where an attacker would
+   actively rewrite messages with a lower protocol version than the
+   messages originally offered by the endpoints.  When multiple versions
+   of MLS are available, the negotiation protocol guarantees that the
+   creator is able to select the best version out of those supported in
+   common by the group.
+
+   In MLS 1.0, the creator of the group is responsible for selecting the
+   best cipher suite supported across clients.  Each client is able to
+   verify availability of protocol version, cipher suites, and
+   extensions at all times once it has at least received the first group
+   operation message.
+
+   Each member of an MLS group advertises the protocol functionality
+   they support.  These capability advertisements can be updated over
+   time, e.g., if client software is updated while the client is a
+   member of a group.  Thus, in addition to preventing downgrade
+   attacks, the members of a group can also observe when it is safe to
+   upgrade to a new cipher suite or protocol version.
+
+7.  Operational Requirements
+
+   MLS is a security layer that needs to be integrated with an
+   application.  A fully functional deployment of MLS will have to make
+   a number of decisions about how MLS is configured and operated.
+   Deployments that wish to interoperate will need to make compatible
+   decisions.  This section lists all of the dependencies of an MLS
+   deployment that are external to the protocol specification, but would
+   still need to be aligned within a given MLS deployment, or for two
+   deployments to potentially interoperate.
+
+   The protocol has a built-in ability to negotiate protocol versions,
+   cipher suites, extensions, credential types, and additional proposal
+   types.  For two deployments to interoperate, they must have
+   overlapping support in each of these categories.  The
+   required_capabilities extension (Section 7.2 of [RFC9420]) can
+   promote interoperability with a wider set of clients by ensuring that
+   certain functionality continues to be supported by a group, even if
+   the clients in the group aren't currently relying on it.
+
+   MLS relies on the following network services, which need to be
+   compatible in order for two different deployments based on them to
+   interoperate.
+
+   *  An *Authentication Service*, described fully in Section 4, defines
+      the types of credentials which may be used in a deployment and
+      provides methods for:
+
+      1.  Issuing new credentials with a relevant credential lifetime,
+
+      2.  Validating a credential against a reference identifier,
+
+      3.  Validating whether or not two credentials represent the same
+          client, and
+
+      4.  Optionally revoking credentials which are no longer
+          authorized.
+
+   *  A *Delivery Service*, described fully in Section 5, provides
+      methods for:
+
+      1.  Delivering messages for a group to all members in the group.
+
+      2.  Delivering Welcome messages to new members of a group.
+
+      3.  Uploading new KeyPackages for a user's own clients.
+
+      4.  Downloading KeyPackages for specific clients.  Typically,
+          KeyPackages are used once and consumed.
+
+   *  Additional services may or may not be required, depending on the
+      application design:
+
+      -  In cases where group operations are not encrypted, the DS has
+         the ability to observe and maintain a copy of the public group
+         state.  In particular, this is useful for either (1) clients
+         that do not have the ability to send the full public state in a
+         Welcome message when inviting a user or (2) clients that need
+         to recover from losing their state.  Such public state can
+         contain privacy-sensitive information such as group members'
+         credentials and related public keys; hence, services need to
+         carefully evaluate the privacy impact of storing this data on
+         the DS.
+
+      -  If external joiners are allowed, there must be a method for
+         publishing a serialized GroupInfo object (with an external_pub
+         extension) that corresponds to a specific group and epoch, and
+         for keeping that object in sync with the state of the group.
+
+      -  If an application chooses not to allow external joining, it may
+         instead provide a method for external users to solicit group
+         members (or a designated service) to add them to a group.
+
+      -  If the application uses PSKs that members of a group may not
+         have access to (e.g., to control entry into the group or to
+         prove membership in the group in the past, as discussed in
+         Section 6.6), there must be a method for distributing these
+         PSKs to group members who might not have them -- for instance,
+         if they joined the group after the PSK was generated.
+
+      -  If an application wishes to detect and possibly discipline
+         members that send malformed commits with the intention of
+         corrupting a group's state, there must be a method for
+         reporting and validating malformed commits.
+
+   MLS requires the following parameters to be defined, which must be
+   the same for two implementations to interoperate:
+
+   *  The maximum total lifetime that is acceptable for a KeyPackage.
+
+   *  How long to store the resumption PSK for past epochs of a group.
+
+   *  The degree of tolerance that's allowed for out-of-order message
+      delivery:
+
+      -  How long to keep unused nonce and key pairs for a sender.
+
+      -  A maximum number of unused key pairs to keep.
+
+      -  A maximum number of steps that clients will move a secret tree
+         ratchet forward in response to a single message before
+         rejecting it.
+
+      -  Whether to buffer messages that aren't yet able to be
+         understood due to other messages not arriving first, and, if
+         so, how many and for how long -- for example, Commit messages
+         that arrive before a proposal they reference or application
+         messages that arrive before the Commit starting an epoch.
+
+   If implementations differ in these parameters, they will interoperate
+   to some extent but may experience unexpected failures in certain
+   situations, such as extensive message reordering.
+
+   MLS provides the following locations where an application may store
+   arbitrary data.  The format and intention of any data in these
+   locations must align for two deployments to interoperate:
+
+   *  Application data, sent as the payload of an encrypted message.
+
+   *  Additional authenticated data, sent unencrypted in an otherwise
+      encrypted message.
+
+   *  Group IDs, as decided by group creators and used to uniquely
+      identify a group.
+
+   *  Application-level identifiers of public key material
+      (specifically, the application_id extension as defined in
+      Section 5.3.3 of [RFC9420]).
+
+   MLS requires the following policies to be defined, which restrict the
+   set of acceptable behaviors in a group.  These policies must be
+   consistent between deployments for them to interoperate:
+
+   *  A policy on which cipher suites are acceptable.
+
+   *  A policy on any mandatory or forbidden MLS extensions.
+
+   *  A policy on when to send proposals and commits in plaintext
+      instead of encrypted.
+
+   *  A policy for which proposals are valid to have in a commit,
+      including but not limited to:
+
+      -  When a member is allowed to add or remove other members of the
+         group.
+
+      -  When, and under what circumstances, a reinitialization proposal
+         is allowed.
+
+      -  When proposals from external senders are allowed and how to
+         authorize those proposals.
+
+      -  When external joiners are allowed and how to authorize those
+         external commits.
+
+      -  Which other proposal types are allowed.
+
+   *  A policy of when members should commit pending proposals in a
+      group.
+
+   *  A policy of how to protect and share the GroupInfo objects needed
+      for external joins.
+
+   *  A policy for when two credentials represent the same client,
+      distinguishing the following two cases:
+
+      -  When there are multiple devices for a given user.
+
+      -  When a single device has multiple signature keys -- for
+         instance, if the device has keys corresponding to multiple
+         overlapping time periods.
+
+   *  A policy on how long to allow a member to stay in a group without
+      updating its leaf keys before removing them.
+
+   Finally, there are some additional application-defined behaviors that
+   are partially an individual application's decision but may overlap
+   with interoperability:
+
+   *  When and how to pad messages.
+
+   *  When to send a reinitialization proposal.
+
+   *  How often clients should update their leaf keys.
+
+   *  Whether to prefer sending full commits or partial/empty commits.
+
+   *  Whether there should be a required_capabilities extension in
+      groups.
+
+8.  Security and Privacy Considerations
+
+   MLS adopts the Internet threat model [RFC3552] and therefore assumes
+   that the attacker has complete control of the network.  It is
+   intended to provide the security services described in Section 8.2 in
+   the face of attackers who can:
+
+   *  Monitor the entire network.
+
+   *  Read unprotected messages.
+
+   *  Generate, inject, and delete any message in the unprotected
+      transport layer.
+
+   While MLS should be run over a secure transport such as QUIC
+   [RFC9000] or TLS [RFC8446], the security guarantees of MLS do not
+   depend on the transport.  This departs from the usual design practice
+   of trusting the transport because MLS is designed to provide security
+   even in the face of compromised network elements, especially the DS.
+
+   Generally, MLS is designed under the assumption that the transport
+   layer is present to keep metadata private from network observers,
+   while the MLS protocol provides confidentiality, integrity, and
+   authentication guarantees for the application data (which could pass
+   through multiple systems).  Additional properties such as partial
+   anonymity or deniability could also be achieved in specific
+   architecture designs.
+
+   In addition, these guarantees are intended to degrade gracefully in
+   the presence of compromise of the transport security links as well as
+   of both clients and elements of the messaging system, as described in
+   the remainder of this section.
+
+8.1.  Assumptions on Transport Security Links
+
+   As discussed above, MLS provides the highest level of security when
+   its messages are delivered over an encrypted transport, thus
+   preventing attackers from selectively interfering with MLS
+   communications as well as protecting the already limited amount of
+   metadata.  Very little information is contained in the unencrypted
+   header of the MLS protocol message format for group operation
+   messages, and application messages are always encrypted in MLS.
+
+      *Recommendation:* Use transports that provide reliability and
+      metadata confidentiality whenever possible, e.g., by transmitting
+      MLS messages over a protocol such as TLS [RFC8446] or QUIC
+      [RFC9000].
+
+   MLS avoids the need to send the full list of recipients to the server
+   for dispatching messages because that list could potentially contain
+   tens of thousands of recipients.  Header metadata in MLS messages
+   typically consists of an opaque group_id, a numerical value to
+   determine the epoch of the group (the number of changes that have
+   been made to the group), and whether the message is an application
+   message, a proposal, or a commit.
+
+   Even though some of this metadata information does not consist of
+   sensitive information, when correlated with other data a network
+   observer might be able to reconstruct sensitive information.  Using a
+   secure channel to transfer this information will prevent a network
+   attacker from accessing this MLS protocol metadata if it cannot
+   compromise the secure channel.
+
+8.1.1.  Integrity and Authentication of Custom Metadata
+
+   MLS provides an authenticated "Additional Authenticated Data" (AAD)
+   field for applications to make data available outside a
+   PrivateMessage, while cryptographically binding it to the message.
+
+      *Recommendation:* Use the "Additional Authenticated Data" field of
+      the PrivateMessage instead of using other unauthenticated means of
+      sending metadata throughout the infrastructure.  If the data
+      should be kept private, the infrastructure should use encrypted
+      application messages instead.
+
+8.1.2.  Metadata Protection for Unencrypted Group Operations
+
+   Having no secure channel to exchange MLS messages can have a serious
+   impact on privacy when transmitting unencrypted group operation
+   messages.  Observing the contents and signatures of the group
+   operation messages may lead an adversary to extract information about
+   the group membership.
+
+      *Recommendation:* Never use the unencrypted mode for group
+      operations without using a secure channel for the transport layer.
+
+8.1.3.  DoS Protection
+
+   In general, we do not consider DoS resistance to be the
+   responsibility of the protocol.  However, it should not be possible
+   for anyone aside from the DS to perform a trivial DoS attack from
+   which it is hard to recover.  This can be achieved through the secure
+   transport layer, which prevents selective attack on MLS
+   communications by network attackers.
+
+   In the centralized setting, DoS protection can typically be performed
+   by using tickets or cookies which identify users to a service for a
+   certain number of connections.  Such a system helps in preventing
+   anonymous clients from sending arbitrary numbers of group operation
+   messages to the DS or the MLS clients.
+
+      *Recommendation:* Use credentials uncorrelated with specific users
+      to help prevent DoS attacks, in a privacy-preserving manner.  Note
+      that the privacy of these mechanisms has to be adjusted in
+      accordance with the privacy expected from secure transport links.
+      (See more discussion in the next section.)
+
+8.1.4.  Message Suppression and Error Correction
+
+   As noted above, MLS is designed to provide some robustness in the
+   face of tampering within the secure transport, e.g., tampering by the
+   DS.  The confidentiality and authenticity properties of MLS prevent
+   the DS from reading or writing messages.  MLS also provides a few
+   tools for detecting message suppression, with the caveat that message
+   suppression cannot always be distinguished from transport failure.
+
+   Each encrypted MLS message carries a per-sender incrementing
+   "generation" number.  If a group member observes a gap in the
+   generation sequence for a sender, then they know that they have
+   missed a message from that sender.  MLS also provides a facility for
+   group members to send authenticated acknowledgments of application
+   messages received within a group.
+
+   As discussed in Section 5, the DS is trusted to select the single
+   Commit message that is applied in each epoch from among the Commits
+   sent by group members.  Since only one Commit per epoch is
+   meaningful, it's not useful for the DS to transmit multiple Commits
+   to clients.  The risk remains that the DS will use the ability
+   maliciously.
+
+8.2.  Intended Security Guarantees
+
+   MLS aims to provide a number of security guarantees, covering
+   authentication, as well as confidentiality guarantees to different
+   degrees in different scenarios.
+
+8.2.1.  Message Secrecy and Authentication
+
+   MLS enforces the encryption of application messages and thus
+   generally guarantees authentication and confidentiality of
+   application messages sent in a group.
+
+   In particular, this means that only other members of a given group
+   can decrypt the payload of a given application message, which
+   includes information about the sender of the message.
+
+   Similarly, group members receiving a message from another group
+   member can authenticate that group member as the sender of the
+   message and verify the message's integrity.
+
+   Message content can be deniable if the signature keys are exchanged
+   over a deniable channel prior to signing messages.
+
+   Depending on the group settings, handshake messages can be encrypted
+   as well.  If that is the case, the same security guarantees apply.
+
+   MLS optionally allows the addition of padding to messages, mitigating
+   the amount of information leaked about the length of the plaintext to
+   an observer on the network.
+
+8.2.2.  Forward Secrecy and Post-Compromise Security
+
+   MLS provides additional protection regarding secrecy of past messages
+   and future messages.  These cryptographic security properties are
+   forward secrecy (FS) and post-compromise security (PCS).
+
+   FS means that access to all encrypted traffic history combined with
+   access to all current keying material on clients will not defeat the
+   secrecy properties of messages older than the oldest key of the
+   compromised client.  Note that this means that clients have to delete
+   the appropriate keys as soon as they have been used with the expected
+   message; otherwise, the secrecy of the messages and the security of
+   MLS are considerably weakened.
+
+   PCS means that if a group member's state is compromised at some time
+   t1 but the group member subsequently performs an update at some time
+   t2, then all MLS guarantees apply to messages sent by the member
+   after time t2 and to messages sent by other members after they have
+   processed the update.  For example, if an attacker learns all secrets
+   known to Alice at time t1, including both Alice's long-term secret
+   keys and all shared group keys, but Alice performs a key update at
+   time t2, then the attacker is unable to violate any of the MLS
+   security properties after the updates have been processed.
+
+   Both of these properties are satisfied even against compromised DSs
+   and ASes in the case where some other mechanism for verifying keys is
+   in use, such as Key Transparency [KT].
+
+   Confidentiality is mainly ensured on the client side.  Because FS and
+   PCS rely on the active deletion and replacement of keying material,
+   any client which is persistently offline may still be holding old
+   keying material and thus be a threat to both FS and PCS if it is
+   later compromised.
+
+   MLS partially defends against this problem by active members
+   including new keying material.  However, not much can be done on the
+   inactive side especially in the case where the client has not
+   processed messages.
+
+      *Recommendation:* Mandate key updates from clients that are not
+      otherwise sending messages and evict clients that are idle for too
+      long.
+
+   These recommendations will reduce the ability of idle compromised
+   clients to decrypt a potentially long set of messages that might have
+   been sent after the point of compromise.
+
+   The precise details of such mechanisms are a matter of local policy
+   and beyond the scope of this document.
+
+8.2.3.  Non-Repudiation vs. Deniability
+
+   MLS provides strong authentication within a group, such that a group
+   member cannot send a message that appears to be from another group
+   member.  Additionally, some services require that a recipient be able
+   to prove to the service provider that a message was sent by a given
+   client, in order to report abuse.  MLS supports both of these use
+   cases.  In some deployments, these services are provided by
+   mechanisms which allow the receiver to prove a message's origin to a
+   third party.  This is often called "non-repudiation".
+
+   Roughly speaking, "deniability" is the opposite of "non-repudiation",
+   i.e., the property that it is impossible to prove to a third party
+   that a message was sent by a given sender.  MLS does not make any
+   claims with regard to deniability.  It may be possible to operate MLS
+   in ways that provide certain deniability properties, but defining the
+   specific requirements and resulting notions of deniability requires
+   further analysis.
+
+8.2.4.  Associating a User's Clients
+
+   When a user has multiple devices, the base MLS protocol only
+   describes how to operate each device as a distinct client in the MLS
+   groups that the user is a member of.  As a result, the other members
+   of the group will be able to identify which of a user's devices sent
+   each message and, therefore, which device the user was using at the
+   time.  Group members would also be able to detect when the user adds
+   or removes authorized devices from their account.  For some
+   applications, this may be an unacceptable breach of the user's
+   privacy.
+
+   This risk only arises when the leaf nodes for the clients in question
+   provide data that can be used to correlate the clients.  One way to
+   mitigate this risk is by only doing client-level authentication
+   within MLS.  If user-level authentication is still desirable, the
+   application would have to provide it through some other mechanism.
+
+   It is also possible to maintain user-level authentication while
+   hiding information about the clients that a user owns.  This can be
+   done by having the clients share cryptographic state, so that they
+   appear as a single client within the MLS group.  Appearing as a
+   single client has the privacy benefits of no longer leaking which
+   device was used to send a particular message and no longer leaking
+   the user's authorized devices.  However, the application would need
+   to provide a synchronization mechanism so that the state of each
+   client remains consistent across changes to the MLS group.  Flaws in
+   this synchronization mechanism may impair the ability of the user to
+   recover from a compromise of one of their devices.  In particular,
+   state synchronization may make it easier for an attacker to use one
+   compromised device to establish exclusive control of a user's
+   account, locking them out entirely and preventing them from
+   recovering.
+
+8.3.  Endpoint Compromise
+
+   The MLS protocol adopts a threat model which includes multiple forms
+   of endpoint/client compromise.  While adversaries are in a strong
+   position if they have compromised an MLS client, there are still
+   situations where security guarantees can be recovered thanks to the
+   PCS properties achieved by the MLS protocol.
+
+   In this section we will explore the consequences and recommendations
+   regarding the following compromise scenarios:
+
+   *  The attacker has access to a symmetric encryption key.
+
+   *  The attacker has access to an application ratchet secret.
+
+   *  The attacker has access to the group secrets for one group.
+
+   *  The attacker has access to a signature oracle for any group.
+
+   *  The attacker has access to the signature key for one group.
+
+   *  The attacker has access to all secrets of a user for all groups
+      (full state compromise).
+
+8.3.1.  Compromise of Symmetric Keying Material
+
+   As described above, each MLS epoch creates a new group secret.
+
+   These group secrets are then used to create a per-sender ratchet
+   secret, which in turn is used to create a per-sender Authenticated
+   Encryption with Associated Data (AEAD) [RFC5116] key that is then
+   used to encrypt MLS plaintext messages.  Each time a message is sent,
+   the ratchet secret is used to create a new ratchet secret and a new
+   corresponding AEAD key.  Because of the properties of the key
+   derivation function, it is not possible to compute a ratchet secret
+   from its corresponding AEAD key or compute ratchet secret n-1 from
+   ratchet secret n.
+
+   Below, we consider the compromise of each of these pieces of keying
+   material in turn, in ascending order of severity.  While this is a
+   limited kind of compromise, it can be realistic in cases of
+   implementation vulnerabilities where only part of the memory leaks to
+   the adversary.
+
+8.3.1.1.  Compromise of AEAD Keys
+
+   In some circumstances, adversaries may have access to specific AEAD
+   keys and nonces which protect an application message or a group
+   operation message.  Compromise of these keys allows the attacker to
+   decrypt the specific message encrypted with that key but no other;
+   because the AEAD keys are derived from the ratchet secret, it cannot
+   generate the next ratchet secret and hence not the next AEAD key.
+
+   In the case of an application message, an AEAD key compromise means
+   that the encrypted application message will be leaked as well as the
+   signature over that message.  This means that the compromise has both
+   confidentiality and privacy implications on the future AEAD
+   encryptions of that chain.  In the case of a group operation message,
+   only the privacy is affected, as the signature is revealed, because
+   the secrets themselves are protected by Hybrid Public Key Encryption
+   (HPKE).  Note that under that compromise scenario, authentication is
+   not affected in either of these cases.  As every member of the group
+   can compute the AEAD keys for all the chains (they have access to the
+   group secrets) in order to send and receive messages, the
+   authentication provided by the AEAD encryption layer of the common
+   framing mechanism is weak.  Successful decryption of an AEAD
+   encrypted message only guarantees that some member of the group -- or
+   in this case an attacker who has compromised the AEAD keys -- sent
+   the message.
+
+   Compromise of the AEAD keys allows the attacker to send an encrypted
+   message using that key, but the attacker cannot send a message to a
+   group that appears to be from any valid client because the attacker
+   cannot forge the signature.  This applies to all the forms of
+   symmetric key compromise described in Section 8.3.1.
+
+8.3.1.2.  Compromise of Ratchet Secret Material
+
+   When a ratchet secret is compromised, the adversary can compute both
+   the current AEAD keys for a given sender and any future keys for that
+   sender in this epoch.  Thus, it can decrypt current and future
+   messages by the corresponding sender.  However, because it does not
+   have previous ratchet secrets, it cannot decrypt past messages as
+   long as those secrets and keys have been deleted.
+
+   Because of its forward secrecy guarantees, MLS will also retain
+   secrecy of all other AEAD keys generated for _other_ MLS clients,
+   outside this dedicated chain of AEAD keys and nonces, even within the
+   epoch of the compromise.  MLS provides post-compromise security
+   against an active adaptive attacker across epochs for AEAD
+   encryption, which means that as soon as the epoch is changed, if the
+   attacker does not have access to more secret material they won't be
+   able to access any protected messages from future epochs.
+
+8.3.1.3.  Compromise of the Group Secrets of a Single Group for One or
+          More Group Epochs
+
+   An adversary who gains access to a set of group secrets -- as when a
+   member of the group is compromised -- is significantly more powerful.
+   In this section, we consider the case where the signature keys are
+   not compromised.  This can occur if the attacker has access to part
+   of the memory containing the group secrets but not to the signature
+   keys which might be stored in a secure enclave.
+
+   In this scenario, the adversary gains the ability to compute any
+   number of ratchet secrets for the epoch and their corresponding AEAD
+   encryption keys and thus can encrypt and decrypt all messages for the
+   compromised epochs.
+
+   If the adversary is passive, it is expected from the PCS properties
+   of the MLS protocol that as soon as the compromised party remediates
+   the compromise and sends an honest Commit message, the next epochs
+   will provide message secrecy.
+
+   If the adversary is active, the adversary can engage in the protocol
+   itself and perform updates on behalf of the compromised party with no
+   ability for an honest group to recover message secrecy.  However, MLS
+   provides PCS against active adaptive attackers through its Remove
+   group operation.  This means that as long as other members of the
+   group are honest, the protocol will guarantee message secrecy for all
+   messages exchanged in the epochs after the compromised party has been
+   removed.
+
+8.3.2.  Compromise by an Active Adversary with the Ability to Sign
+        Messages
+
+   If an active adversary has compromised an MLS client and can sign
+   messages, two different scenarios emerge.  In the strongest
+   compromise scenario, the attacker has access to the signing key and
+   can forge authenticated messages.  In a weaker, yet realistic
+   scenario, the attacker has compromised a client but the client
+   signature keys are protected with dedicated hardware features which
+   do not allow direct access to the value of the private key and
+   instead provide a signature API.
+
+   When considering an active adaptive attacker with access to a
+   signature oracle, the compromise scenario implies a significant
+   impact on both the secrecy and authentication guarantees of the
+   protocol, especially if the attacker also has access to the group
+   secrets.  In that case, both secrecy and authentication are broken.
+   The attacker can generate any message, for the current and future
+   epochs, until the compromise is remediated and the formerly
+   compromised client sends an honest update.
+
+   Note that under this compromise scenario, the attacker can perform
+   all operations which are available to a legitimate client even
+   without access to the actual value of the signature key.
+
+8.3.3.  Compromise of Authentication with Access to a Signature Key
+
+   The difference between having access to the value of the signature
+   key and only having access to a signing oracle is not about the
+   ability of an active adaptive network attacker to perform different
+   operations during the time of the compromise; the attacker can
+   perform every operation available to a legitimate client in both
+   cases.
+
+   There is a significant difference, however, in terms of recovery
+   after a compromise.
+
+   Because of the PCS guarantees provided by the MLS protocol, when a
+   previously compromised client recovers from compromise and performs
+   an honest Commit, both secrecy and authentication of future messages
+   can be recovered as long as the attacker doesn't otherwise get access
+   to the key.  Because the adversary doesn't have the signing key, they
+   cannot authenticate messages on behalf of the compromised party, even
+   if they still have control over some group keys by colluding with
+   other members of the group.
+
+   This is in contrast with the case where the signature key is leaked.
+   In that case, the compromised endpoint needs to refresh its
+   credentials and invalidate the old credentials before the attacker
+   will be unable to authenticate messages.
+
+   Beware that in both oracle and private key access, an active adaptive
+   attacker can follow the protocol and request to update its own
+   credential.  This in turn induces a signature key rotation, which
+   could provide the attacker with part or the full value of the private
+   key, depending on the architecture of the service provider.
+
+      *Recommendation:* Signature private keys should be
+      compartmentalized from other secrets and preferably protected by a
+      Hardware Security Module (HSM) or dedicated hardware features to
+      allow recovery of the authentication for future messages after a
+      compromise.
+
+      *Recommendation:* When the credential type supports revocation,
+      the users of a group should check for revoked keys.
+
+8.3.4.  Security Considerations in the Context of a Full State
+        Compromise
+
+   In real-world compromise scenarios, it is often the case that
+   adversaries target specific devices to obtain parts of the memory or
+   even the ability to execute arbitrary code in the targeted device.
+
+   Also, recall that in this setting, the application will often retain
+   the unencrypted messages.  If so, the adversary does not have to
+   break encryption at all to access sent and received messages.
+   Messages may also be sent by using the application to instruct the
+   protocol implementation.
+
+      *Recommendation:* If messages are stored on the device, they
+      should be protected using encryption at rest, and the keys used
+      should be stored securely using dedicated mechanisms on the
+      device.
+
+      *Recommendation:* If the threat model of the system includes an
+      adversary that can access the messages on the device without even
+      needing to attack MLS, the application should delete plaintext and
+      ciphertext messages as soon as practical after encryption or
+      decryption.
+
+   Note that this document makes a clear distinction between the way
+   signature keys and other group shared secrets must be handled.  In
+   particular, a large set of group secrets cannot necessarily be
+   assumed to be protected by an HSM or secure enclave features.  This
+   is especially true because these keys are frequently used and changed
+   with each message received by a client.
+
+   However, the signature private keys are mostly used by clients to
+   send a message.  They also provide strong authentication guarantees
+   to other clients; hence, we consider that their protection by
+   additional security mechanisms should be a priority.
+
+   Overall, there is no way to detect or prevent these compromises, as
+   discussed in the previous sections: Performing separation of the
+   application secret states can help recovery after compromise; this is
+   the case for signature keys, but similar concerns exist for a
+   client's encryption private keys.
+
+      *Recommendation:* The secret keys used for public key encryption
+      should be stored similarly to the way the signature keys are
+      stored, as keys can be used to decrypt the group operation
+      messages and contain the secret material used to compute all the
+      group secrets.
+
+   Even if secure enclaves are not perfectly secure or are even
+   completely broken, adopting additional protections for these keys can
+   ease recovery of the secrecy and authentication guarantees after a
+   compromise where, for instance, an attacker can sign messages without
+   having access to the key.  In certain contexts, the rotation of
+   credentials might only be triggered by the AS through ACLs and hence
+   be beyond the capabilities of the attacker.
+
+8.4.  Service Node Compromise
+
+8.4.1.  General Considerations
+
+8.4.1.1.  Privacy of the Network Connections
+
+   There are many scenarios leading to communication between the
+   application on a device and the DS or the AS.  In particular, when:
+
+   *  The application connects to the AS to generate or validate a new
+      credential before distributing it.
+
+   *  The application fetches credentials at the DS prior to creating a
+      messaging group (one-to-one or more than two clients).
+
+   *  The application fetches service provider information or messages
+      on the DS.
+
+   *  The application sends service provider information or messages to
+      the Delivery Service.
+
+   In all these cases, the application will often connect to the device
+   via a secure transport which leaks information about the origin of
+   the request, such as the IP address and -- depending on the protocol
+   -- the MAC address of the device.
+
+   Similar concerns exist in the peer-to-peer use cases for MLS.
+
+      *Recommendation:* In the case where privacy or anonymity is
+      important, using adequate protection such as Multiplexed
+      Application Substrate over QUIC Encryption (MASQUE)
+      [MASQUE-PROXY], Tor [Tor], or a VPN can improve metadata
+      protection.
+
+   More generally, using anonymous credentials in an MLS-based
+   architecture might not be enough to provide strong privacy or
+   anonymity properties.
+
+8.4.1.2.  Storage of Metadata and Encryption at Rest on the Servers
+
+   In the case where private data or metadata has to be persisted on the
+   servers for functionality (mappings between identities and push
+   tokens, group metadata, etc.), it should be stored encrypted at rest
+   and only decrypted upon need during the execution.  Honest service
+   providers can rely on such "encryption at rest" mechanisms to be able
+   to prevent access to the data when not using it.
+
+      *Recommendation:* Store cryptographic material used for server-
+      side decryption of sensitive metadata on the clients and only send
+      it when needed.  The server can use the secret to open and update
+      encrypted data containers after which they can delete these keys
+      until the next time they need it, in which case those can be
+      provided by the client.
+
+      *Recommendation:* Rely on group secrets exported from the MLS
+      session for server-side encryption at rest and update the key
+      after each removal from the group.  Otherwise, rotate those keys
+      on a regular basis.
+
+8.4.2.  Delivery Service Compromise
+
+   MLS is intended to provide strong guarantees in the face of
+   compromise of the DS.  Even a totally compromised DS should not be
+   able to read messages or inject messages that will be acceptable to
+   legitimate clients.  It should also not be able to undetectably
+   remove, reorder, or replay messages.
+
+   However, a malicious DS can mount a variety of DoS attacks on the
+   system, including total DoS attacks (where it simply refuses to
+   forward any messages) and partial DoS attacks (where it refuses to
+   forward messages to and from specific clients).  As noted in
+   Section 5.2, these attacks are only partially detectable by clients
+   without an out-of-band channel.  Ultimately, failure of the DS to
+   provide reasonable service must be dealt with as a customer service
+   matter, not via technology.
+
+   Because the DS is responsible for providing the initial keying
+   material to clients, it can provide stale keys.  This does not
+   inherently lead to compromise of the message stream, but does allow
+   the DS to attack post-compromise security to a limited extent.  This
+   threat can be mitigated by having initial keys expire.
+
+   Initial keying material (KeyPackages) using the basic credential type
+   is more vulnerable to replacement by a malicious or compromised DS,
+   as there is no built-in cryptographic binding between the identity
+   and the public key of the client.
+
+      *Recommendation:* Prefer a credential type in KeyPackages which
+      includes a strong cryptographic binding between the identity and
+      its key (for example, the x509 credential type).  When using the
+      basic credential type, take extra care to verify the identity
+      (typically out of band).
+
+8.4.2.1.  Privacy of Delivery and Push Notifications
+
+   Push tokens provide an important mechanism that is often ignored from
+   the standpoint of privacy considerations.  In many modern messaging
+   architectures, applications are using push notification mechanisms
+   typically provided by OS vendors.  This is to make sure that when
+   messages are available at the DS (or via other mechanisms if the DS
+   is not a central server), the recipient application on a device knows
+   about it.  Sometimes the push notification can contain the
+   application message itself, which saves a round trip with the DS.
+
+   To "push" this information to the device, the service provider and
+   the OS infrastructures use unique per-device, per-application
+   identifiers called push tokens.  This means that the push
+   notification provider and the service provider have information on
+   which devices receive information and at which point in time.
+   Alternatively, non-mobile applications could use a WebSocket or
+   persistent connection for notifications directly from the DS.
+
+   Even though the service provider and the push notification provider
+   can't necessarily access the content (typically encrypted MLS
+   messages), no technical mechanism in MLS prevents them from
+   determining which devices are recipients of the same message.
+
+   For secure messaging systems, push notifications are often sent in
+   real time, as it is not acceptable to create artificial delays for
+   message retrieval.
+
+      *Recommendation:* If real-time notifications are not necessary,
+      one can delay notifications randomly across recipient devices
+      using a mixnet or other techniques.
+
+   Note that with a legal request to ask the service provider for the
+   push token associated with an identifier, it is easy to correlate the
+   token with a second request to the company operating the push
+   notification system to get information about the device, which is
+   often linked with a real identity via a cloud account, a credit card,
+   or other information.
+
+      *Recommendation:* If stronger privacy guarantees are needed with
+      regard to the push notification provider, the client can choose to
+      periodically connect to the DS without the need of a dedicated
+      push notification infrastructure.
+
+   Applications can also consider anonymous systems for server fanout
+   (for example, [Loopix]).
+
+8.4.3.  Authentication Service Compromise
+
+   The Authentication Service design is left to the infrastructure
+   designers.  In most designs, a compromised AS is a serious matter, as
+   the AS can serve incorrect or attacker-provided identities to
+   clients.
+
+   *  The attacker can link an identity to a credential.
+
+   *  The attacker can generate new credentials.
+
+   *  The attacker can sign new credentials.
+
+   *  The attacker can publish or distribute credentials.
+
+   An attacker that can generate or sign new credentials may or may not
+   have access to the underlying cryptographic material necessary to
+   perform such operations.  In that last case, it results in windows of
+   time for which all emitted credentials might be compromised.
+
+      *Recommendation:* Use HSMs to store the root signature keys to
+      limit the ability of an adversary with no physical access to
+      extract the top-level signature private key.
+
+   Note that historically some systems generate signature keys on the AS
+   and distribute the private keys to clients along with their
+   credential.  This is a dangerous practice because it allows the AS or
+   an attacker who has compromised the AS to silently impersonate the
+   client.
+
+8.4.3.1.  Authentication Compromise: Ghost Users and Impersonation
+
+   One important property of MLS is that all members know which other
+   members are in the group at all times.  If all members of the group
+   and the AS are honest, no parties other than the members of the
+   current group can read and write messages protected by the protocol
+   for that group.
+
+   This guarantee applies to the cryptographic identities of the
+   members.  Details about how to verify the identity of a client depend
+   on the MLS credential type used.  For example, cryptographic
+   verification of credentials can be largely performed autonomously
+   (e.g., without user interaction) by the clients themselves for the
+   x509 credential type.
+
+   In contrast, when MLS clients use the basic credential type, some
+   other mechanism must be used to verify identities.  For instance, the
+   Authentication Service could operate some sort of directory server to
+   provide keys, or users could verify keys via an out-of-band
+   mechanism.
+
+      *Recommendation:* Select the MLS credential type with the
+      strongest security which is supported by all target members of an
+      MLS group.
+
+      *Recommendation:* Do not use the same signature key pair across
+      groups.  Update all keys for all groups on a regular basis.  Do
+      not preserve keys in different groups when suspecting a
+      compromise.
+
+   If the AS is compromised, it could validate a signature key pair (or
+   generate a new one) for an attacker.  The attacker could then use
+   this key pair to join a group as if it were another of the user's
+   clients.  Because a user can have many MLS clients running the MLS
+   protocol, it possibly has many signature key pairs for multiple
+   devices.  These attacks could be very difficult to detect, especially
+   in large groups where the UI might not reflect all the changes back
+   to the users.  If the application participates in a key transparency
+   mechanism in which it is possible to determine every key for a given
+   user, then this would allow for detection of surreptitiously created
+   false credentials.
+
+      *Recommendation:* Make sure that MLS clients reflect all the
+      membership changes to the users as they happen.  If a choice has
+      to be made because the number of notifications is too high, the
+      client should provide a log of state of the device so that the
+      user can examine it.
+
+      *Recommendation:* Provide a key transparency mechanism for the AS
+      to allow public verification of the credentials authenticated by
+      this service.
+
+   While the ways to handle MLS credentials are not defined by the
+   protocol or the architecture documents, the MLS protocol has been
+   designed with a mechanism that can be used to provide out-of-band
+   authentication to users.  The authentication_secret generated for
+   each user at each epoch of the group is a one-time, per-client
+   authentication secret which can be exchanged between users to prove
+   their identities to each other.  This can be done, for instance,
+   using a QR code that can be scanned by the other parties.
+
+      *Recommendation:* Provide one or more out-of-band authentication
+      mechanisms to limit the impact of an AS compromise.
+
+   We note, again, that the AS may not be a centralized system and could
+   be realized by many mechanisms such as establishing prior one-to-one
+   deniable channels, gossiping, or using trust on first use (TOFU) for
+   credentials used by the MLS protocol.
+
+   Another important consideration is the ease of redistributing new
+   keys on client compromise, which helps recovering security faster in
+   various cases.
+
+8.4.3.2.  Privacy of the Group Membership
+
+   Group membership is itself sensitive information, and MLS is designed
+   to limit the amount of persistent metadata.  However, large groups
+   often require an infrastructure that provides server fanout.  In the
+   case of client fanout, the destination of a message is known by all
+   clients; hence, the server usually does not need this information.
+   However, servers may learn this information through traffic analysis.
+   Unfortunately, in a server-side fanout model, the Delivery Service
+   can learn that a given client is sending the same message to a set of
+   other clients.  In addition, there may be applications of MLS in
+   which the group membership list is stored on some server associated
+   with the DS.
+
+   While this knowledge is not a breach of the protocol's authentication
+   or confidentiality guarantees, it is a serious issue for privacy.
+
+   Some infrastructures keep a mapping between keys used in the MLS
+   protocol and user identities.  An attacker with access to this
+   information due to compromise or regulation can associate unencrypted
+   group messages (e.g., Commits and Proposals) with the corresponding
+   user identity.
+
+      *Recommendation:* Use encrypted group operation messages to limit
+      privacy risks whenever possible.
+
+   In certain cases, the adversary can access specific bindings between
+   public keys and identities.  If the signature keys are reused across
+   groups, the adversary can get more information about the targeted
+   user.
+
+      *Recommendation:* Ensure that linking between public keys and
+      identities only happens in expected scenarios.
+
+8.5.  Considerations for Attacks Outside of the Threat Model
+
+   Physical attacks on devices storing and executing MLS principals are
+   not considered in depth in the threat model of the MLS protocol.
+   While non-permanent, non-invasive attacks can sometimes be equivalent
+   to software attacks, physical attacks are considered outside of the
+   MLS threat model.
+
+   Compromise scenarios typically consist of a software adversary, which
+   can maintain active adaptive compromise and arbitrarily change the
+   behavior of the client or service.
+
+   On the other hand, security goals consider that honest clients will
+   always run the protocol according to its specification.  This relies
+   on implementations of the protocol to securely implement the
+   specification, which remains non-trivial.
+
+      *Recommendation:* Additional steps should be taken to protect the
+      device and the MLS clients from physical compromise.  In such
+      settings, HSMs and secure enclaves can be used to protect
+      signature keys.
+
+8.6.  No Protection Against Replay by Insiders
+
+   MLS does not protect against one group member replaying a
+   PrivateMessage sent by another group member within the same epoch
+   that the message was originally sent.  Similarly, MLS does not
+   protect against the replay (by a group member or otherwise) of a
+   PublicMessage within the same epoch that the message was originally
+   sent.  Applications for whom replay is an important risk should apply
+   mitigations at the application layer, as discussed below.
+
+   In addition to the risks discussed in Section 8.3.1, an attacker with
+   access to the ratchet secrets for an endpoint can replay
+   PrivateMessage objects sent by other members of the group by taking
+   the signed content of the message and re-encrypting it with a new
+   generation of the original sender's ratchet.  If the other members of
+   the group interpret a message with a new generation as a fresh
+   message, then this message will appear fresh.  (This is possible
+   because the message signature does not cover the generation field of
+   the message.)  Messages sent as PublicMessage objects similarly lack
+   replay protections.  There is no message counter comparable to the
+   generation field in PrivateMessage.
+
+   Applications can detect replay by including a unique identifier for
+   the message (e.g., a counter) in either the message payload or the
+   authenticated_data field, both of which are included in the
+   signatures for PublicMessage and PrivateMessage.
+
+8.7.  Cryptographic Analysis of the MLS Protocol
+
+   Various academic works have analyzed MLS and the different security
+   guarantees it aims to provide.  The security of large parts of the
+   protocol has been analyzed by [BBN19] (for MLS Draft 7), [ACDT21]
+   (for MLS Draft 11), and [AJM20] (for MLS Draft 12).
+
+   Individual components of various drafts of the MLS protocol have been
+   analyzed in isolation and with differing adversarial models.  For
+   example, [BBR18], [ACDT19], [ACCKKMPPWY19], [AJM20], [ACJM20],
+   [AHKM21], [CGWZ25], and [WPB25] analyze the ratcheting tree sub-
+   protocol of MLS that facilitates key agreement; [WPBB22] analyzes the
+   sub-protocol of MLS for group state agreement and authentication; and
+   [BCK21] analyzes the key derivation paths in the ratchet tree and key
+   schedule.  Finally, [CHK21] analyzes the authentication and cross-
+   group healing guarantees provided by MLS.
+
+9.  IANA Considerations
+
+   This document has no IANA actions.
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC5116]  McGrew, D., "An Interface and Algorithms for Authenticated
+              Encryption", RFC 5116, DOI 10.17487/RFC5116, January 2008,
+              <https://www.rfc-editor.org/info/rfc5116>.
+
+   [RFC9420]  Barnes, R., Beurdouche, B., Robert, R., Millican, J.,
+              Omara, E., and K. Cohn-Gordon, "The Messaging Layer
+              Security (MLS) Protocol", RFC 9420, DOI 10.17487/RFC9420,
+              July 2023, <https://www.rfc-editor.org/info/rfc9420>.
+
+10.2.  Informative References
+
+   [ACCKKMPPWY19]
+              Alwen, J., Capretto, M., Cueto, M., Kamath, C., Klein, K.,
+              Markov, I., Pascual-Perez, G., Pietrzak, K., Walter, M.,
+              and M. Yeo, "Keep the Dirt: Tainted TreeKEM, Adaptively
+              and Actively Secure Continuous Group Key Agreement",
+              Cryptology ePrint Archive, 2019,
+              <https://eprint.iacr.org/2019/1489>.
+
+   [ACDT19]   Alwen, J., Coretti, S., Dodis, Y., and Y. Tselekounis,
+              "Security Analysis and Improvements for the IETF MLS
+              Standard for Group Messaging", Cryptology ePrint Archive,
+              2019, <https://eprint.iacr.org/2019/1189.pdf>.
+
+   [ACDT21]   Alwen, J., Coretti, S., Dodis, Y., and Y. Tselekounis,
+              "Modular Design of Secure Group Messaging Protocols and
+              the Security of MLS", Cryptology ePrint Archive, 2021,
+              <https://eprint.iacr.org/2021/1083.pdf>.
+
+   [ACJM20]   Alwen, J., Coretti, S., Jost, D., and M. Mularczyk,
+              "Continuous Group Key Agreement with Active Security",
+              Cryptology ePrint Archive, 2020,
+              <https://eprint.iacr.org/2020/752.pdf>.
+
+   [AHKM21]   Alwen, J., Hartmann, D., Kiltz, E., and M. Mularczyk,
+              "Server-Aided Continuous Group Key Agreement", Cryptology
+              ePrint Archive, 2021,
+              <https://eprint.iacr.org/2021/1456.pdf>.
+
+   [AJM20]    Alwen, J., Jost, D., and M. Mularczyk, "On The Insider
+              Security of MLS", Cryptology ePrint Archive, 2020,
+              <https://eprint.iacr.org/2020/1327.pdf>.
+
+   [BBN19]    Bhargavan, K., Beurdouche, B., and P. Naldurg, "Formal
+              Models and Verified Protocols for Group Messaging: Attacks
+              and Proofs for IETF MLS", HAL ID hal-02425229, 2019,
+              <https://inria.hal.science/hal-02425229/document>.
+
+   [BBR18]    Bhargavan, K., Barnes, R., and E. Rescorla, "TreeKEM:
+              Asynchronous Decentralized Key Management for Large
+              Dynamic Groups - A protocol proposal for Messaging Layer
+              Security (MLS)", HAL ID hal-02425247, 2018,
+              <https://hal.inria.fr/hal-02425247/file/
+              treekem+%281%29.pdf>.
+
+   [BCK21]    Brzuska, C., Cornelissen, E., and K. Kohbrok, "Security
+              Analysis of the MLS Key Distribution", Cryptology ePrint
+              Archive, 2021, <https://eprint.iacr.org/2021/137.pdf>.
+
+   [CAPBR]    Brewer, E. A., "Towards robust distributed systems
+              (abstract)", Proceedings of the nineteenth annual ACM
+              symposium on Principles of distributed computing, p. 7,
+              DOI 10.1145/343477.343502, July 2000,
+              <https://dl.acm.org/doi/10.1145/343477.343502>.
+
+   [CGWZ25]   Cremers, C., Günsay, E., Wesselkamp, V., and M. Zhao,
+              "ETK: External-Operations TreeKEM and the Security of MLS
+              in RFC 9420", 2025,
+              <https://eprint.iacr.org/2025/229.pdf>.
+
+   [CHK21]    Cremers, C., Hale, B., and K. Kohbrok, "The Complexities
+              of Healing in Secure Group Messaging: Why Cross-Group
+              Effects Matter", Proceedings of the 30th USENIX Security
+              Symposium, August 2021,
+              <https://www.usenix.org/system/files/sec21-cremers.pdf>.
+
+   [EXTENSIONS]
+              Robert, R., "The Messaging Layer Security (MLS)
+              Extensions", Work in Progress, Internet-Draft, draft-ietf-
+              mls-extensions-06, 19 February 2025,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-mls-
+              extensions-06>.
+
+   [FEDERATION]
+              Omara, E. and R. Robert, "The Messaging Layer Security
+              (MLS) Federation", Work in Progress, Internet-Draft,
+              draft-ietf-mls-federation-03, 9 September 2023,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-mls-
+              federation-03>.
+
+   [KT]       McMillion, B., "Key Transparency Architecture", Work in
+              Progress, Internet-Draft, draft-ietf-keytrans-
+              architecture-03, 25 February 2025,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-
+              keytrans-architecture-03>.
+
+   [Loopix]   Piotrowska, A. M., Hayes, J., Elahi, T., Meiser, S., and
+              G. Danezis, "The Loopix Anonymity System", Proceedings of
+              the 26th USENIX Security Symposium, August 2017.
+
+   [MASQUE-PROXY]
+              Schinazi, D., "The MASQUE Proxy", Work in Progress,
+              Internet-Draft, draft-schinazi-masque-proxy-05, 18
+              February 2025, <https://datatracker.ietf.org/doc/html/
+              draft-schinazi-masque-proxy-05>.
+
+   [RFC3552]  Rescorla, E. and B. Korver, "Guidelines for Writing RFC
+              Text on Security Considerations", BCP 72, RFC 3552,
+              DOI 10.17487/RFC3552, July 2003,
+              <https://www.rfc-editor.org/info/rfc3552>.
+
+   [RFC5280]  Cooper, D., Santesson, S., Farrell, S., Boeyen, S.,
+              Housley, R., and W. Polk, "Internet X.509 Public Key
+              Infrastructure Certificate and Certificate Revocation List
+              (CRL) Profile", RFC 5280, DOI 10.17487/RFC5280, May 2008,
+              <https://www.rfc-editor.org/info/rfc5280>.
+
+   [RFC6120]  Saint-Andre, P., "Extensible Messaging and Presence
+              Protocol (XMPP): Core", RFC 6120, DOI 10.17487/RFC6120,
+              March 2011, <https://www.rfc-editor.org/info/rfc6120>.
+
+   [RFC8446]  Rescorla, E., "The Transport Layer Security (TLS) Protocol
+              Version 1.3", RFC 8446, DOI 10.17487/RFC8446, August 2018,
+              <https://www.rfc-editor.org/info/rfc8446>.
+
+   [RFC9000]  Iyengar, J., Ed. and M. Thomson, Ed., "QUIC: A UDP-Based
+              Multiplexed and Secure Transport", RFC 9000,
+              DOI 10.17487/RFC9000, May 2021,
+              <https://www.rfc-editor.org/info/rfc9000>.
+
+   [Tor]      "The Tor Project", <https://torproject.org/>.
+
+   [WPB25]    Wallez, T., Protzenko, J., and K. Bhargavan, "TreeKEM: A
+              Modular Machine-Checked Symbolic Security Analysis of
+              Group Key Agreement in Messaging Layer Security", 2025,
+              <https://eprint.iacr.org/2025/410.pdf>.
+
+   [WPBB22]   Wallez, T., Protzenko, J., Beurdouche, B., and K.
+              Bhargavan, "TreeSync: Authenticated Group Management for
+              Messaging Layer Security", Cryptology ePrint Archive,
+              2022, <https://eprint.iacr.org/2022/1732.pdf>.
+
+Contributors
+
+   Richard Barnes
+   Cisco
+   Email: rlb@ipv.sx
+
+
+   Katriel Cohn-Gordon
+   Meta Platforms
+   Email: me@katriel.co.uk
+
+
+   Cas Cremers
+   CISPA Helmholtz Center for Information Security
+   Email: cremers@cispa.de
+
+
+   Britta Hale
+   Naval Postgraduate School
+   Email: britta.hale@nps.edu
+
+
+   Albert Kwon
+   Badge Inc.
+   Email: kwonalbert@badgeinc.com
+
+
+   Konrad Kohbrok
+   Phoenix R&D
+   Email: konrad.kohbrok@datashrine.de
+
+
+   Rohan Mahy
+   Wire
+   Email: rohan.mahy@wire.com
+
+
+   Brendan McMillion
+   Email: brendanmcmillion@gmail.com
+
+
+   Thyla van der Merwe
+   Email: tjvdmerwe@gmail.com
+
+
+   Jon Millican
+   Meta Platforms
+   Email: jmillican@meta.com
+
+
+   Raphael Robert
+   Phoenix R&D
+   Email: ietf@raphaelrobert.com
+
+
+Authors' Addresses
+
+   Benjamin Beurdouche
+   Inria & Mozilla
+   Email: ietf@beurdouche.com
+
+
+   Eric Rescorla
+   Email: ekr@rtfm.com
+
+
+   Emad Omara
+   Email: emad.omara@gmail.com
+
+
+   Srinivas Inguva
+   Email: singuva@yahoo.com
+
+
+   Alan Duric
+   Email: alan@duric.net

--- a/justfile
+++ b/justfile
@@ -3,14 +3,48 @@
 default:
     @just --list
 
-# Run tests
+# Run tests with all features (default)
 test:
     cargo test --all-features --all-targets
     cargo test --all-features --doc
 
+# Run tests without optional features
+test-no-features:
+    cargo test --all-targets --no-default-features
+
+# Run tests with only mip04 feature
+test-mip04:
+    cargo test --all-targets --no-default-features --features mip04
+
+# Run all test combinations (like CI)
+test-all:
+    @echo "Testing with all features..."
+    @just test
+    @echo "Testing without optional features..."
+    @just test-no-features
+    @echo "Testing with mip04 feature only..."
+    @just test-mip04
+
 # Check clippy
 lint:
     @bash scripts/check-clippy.sh
+
+# Check clippy without features
+lint-no-features:
+    cargo clippy --all-targets --no-default-features --no-deps -- -D warnings
+
+# Check clippy with mip04 feature only
+lint-mip04:
+    cargo clippy --all-targets --no-default-features --features mip04 --no-deps -- -D warnings
+
+# Check clippy for all feature combinations
+lint-all:
+    @echo "Checking clippy with all features..."
+    @just lint
+    @echo "Checking clippy without optional features..."
+    @just lint-no-features
+    @echo "Checking clippy with mip04 feature only..."
+    @just lint-mip04
 
 # Check fmt
 fmt:
@@ -20,8 +54,19 @@ fmt:
 docs:
     @bash scripts/check-docs.sh
 
-# Check all
+# Check all (comprehensive like CI)
 check:
     @bash scripts/check-all.sh
-    @just test
+    @just test-all
+
+# Full comprehensive check including all feature combinations for clippy
+check-full:
+    @echo "Running format checks..."
+    @just fmt
+    @echo "Running documentation checks..."
+    @just docs
+    @echo "Running clippy checks for all feature combinations..."
+    @just lint-all
+    @echo "Running tests for all feature combinations..."
+    @just test-all
 

--- a/justfile
+++ b/justfile
@@ -25,26 +25,17 @@ test-all:
     @echo "Testing with mip04 feature only..."
     @just test-mip04
 
-# Check clippy
+# Check clippy for all feature combinations
 lint:
     @bash scripts/check-clippy.sh
 
-# Check clippy without features
+# Check clippy without features (for individual testing)
 lint-no-features:
     cargo clippy --all-targets --no-default-features --no-deps -- -D warnings
 
-# Check clippy with mip04 feature only
+# Check clippy with mip04 feature only (for individual testing)
 lint-mip04:
     cargo clippy --all-targets --no-default-features --features mip04 --no-deps -- -D warnings
-
-# Check clippy for all feature combinations
-lint-all:
-    @echo "Checking clippy with all features..."
-    @just lint
-    @echo "Checking clippy without optional features..."
-    @just lint-no-features
-    @echo "Checking clippy with mip04 feature only..."
-    @just lint-mip04
 
 # Check fmt
 fmt:
@@ -59,14 +50,14 @@ check:
     @bash scripts/check-all.sh
     @just test-all
 
-# Full comprehensive check including all feature combinations for clippy
+# Full comprehensive check including all feature combinations
 check-full:
     @echo "Running format checks..."
     @just fmt
     @echo "Running documentation checks..."
     @just docs
     @echo "Running clippy checks for all feature combinations..."
-    @just lint-all
+    @just lint
     @echo "Running tests for all feature combinations..."
     @just test-all
 

--- a/scripts/check-clippy.sh
+++ b/scripts/check-clippy.sh
@@ -10,6 +10,14 @@ cargo +$version --version || rustup install $version
 # Install clippy
 cargo +$version clippy --version || rustup component add clippy --toolchain $version
 
-echo "Checking clippy"
+echo "Checking clippy with all features..."
 cargo +$version clippy --all-targets --all-features --no-deps -- -D warnings
+
+echo "Checking clippy without optional features..."
+cargo +$version clippy --all-targets --no-default-features --no-deps -- -D warnings
+
+echo "Checking clippy with mip04 feature only..."
+cargo +$version clippy --all-targets --no-default-features --features mip04 --no-deps -- -D warnings
+
+echo "All clippy checks passed!"
 echo

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -11,5 +11,5 @@ cargo +$version --version || rustup install $version
 rustdoc +$version --version || rustup component add rust-docs --toolchain $version
 
 echo "Checking docs"
-cargo +$version doc --no-deps --all-features
+RUSTDOCFLAGS="-D warnings" cargo +$version doc --no-deps --all-features --document-private-items
 echo

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -7,9 +7,10 @@ version="1.85.0"
 # Install toolchain
 cargo +$version --version || rustup install $version
 
-# Ensure rustdoc is available
-rustdoc +$version --version || rustup component add rust-docs --toolchain $version
+# Ensure rustdoc is available (installed with the toolchain)
+rustdoc +$version --version >/dev/null
 
 echo "Checking docs"
 RUSTDOCFLAGS="-D warnings" cargo +$version doc --no-deps --all-features --document-private-items
 echo
+


### PR DESCRIPTION
# Add Encrypted Media Support (MIP-04)

This PR implements the Encrypted Media specification (MIP-04) from the Marmot protocol, enabling secure media sharing within MLS groups on Nostr.

## 🎯 Overview

This implementation adds comprehensive support for encrypting, sharing, and decrypting media files (images, videos, audio) within Marmot groups while maintaining end-to-end encryption and privacy guarantees.

## ✨ Key Features

### 🔐 Secure Encryption
- **ChaCha20-Poly1305 AEAD** encryption with tamper protection
- **Deterministic key/nonce derivation** from MLS exporter secrets
- **Associated data (AAD)** binding to prevent metadata tampering
- **Version 1** encryption scheme with forward compatibility

### 📁 Media Processing
- **MIME type validation** for supported formats (JPEG, PNG, WebP, GIF, MP4, WebM, MP3, WAV, OGG)
- **File size limits** (100MB max) and dimension validation (16K max)
- **EXIF stripping** for privacy protection
- **Blurhash generation** for image previews
- **Metadata extraction** with configurable processing options

### 🌐 Storage Integration  
- **Content-addressed storage** support (designed for Blossom protocol)
- **Hash-based addressing** using SHA256 of encrypted content
- **Privacy-preserving** storage addresses (no correlation to original files)
- **NIP-92 compliant** `imeta` tags for metadata sharing

## 📦 Changes

### New Dependencies
- `chacha20poly1305` - AEAD encryption
- `hkdf` - Key derivation functions  
- `image` - Image processing and metadata extraction
- `blurhash` - Image preview generation
- `thiserror` - Error handling

### File Structure
```
crates/mdk-core/src/encrypted_media/
├── mod.rs           # Public API exports
├── types.rs         # Core types, constants, errors
├── manager.rs       # EncryptedMediaManager implementation
├── crypto.rs        # Encryption/decryption operations
├── metadata.rs      # Media processing and EXIF handling
└── validation.rs    # Input validation logic
```

### Feature Flag
- The entire change set is gated behind `mip04` feature flag for optional inclusion

## 🧪 Testing

- ✅ **Unit tests** for all core components
- ✅ **Cryptographic correctness** validation
- ✅ **Error handling** coverage
- ✅ **Type safety** verification
- ✅ **Metadata processing** validation

## 📚 Documentation

### Added Resources
- **MLS RFCs**: RFC 9420 (MLS Protocol), RFC 9750 (MLS Architecture)
- **MLS Extensions**: Draft specification for extended functionality
- **LLM Context**: Workspace rules for Marmot, MLS, and Nostr protocols

### API Documentation
- Comprehensive rustdoc for all public APIs
- Usage examples and error handling guidance
- Protocol compliance notes and security considerations

## 🔄 Protocol Compliance

This implementation fully complies with **MIP-04 Encrypted Media** specification:
- ✅ Deterministic key/nonce derivation
- ✅ ChaCha20-Poly1305 AEAD encryption
- ✅ NIP-92 compliant `imeta` tags
- ✅ Content-addressed storage integration
- ✅ Version 1 encryption scheme with forward compatibility

## 🚀 Usage Example

```rust
use mdk_core::encrypted_media::{EncryptedMediaManager, MediaProcessingOptions};

// Create manager for a group
let manager = EncryptedMediaManager::new(&mdk, group_id);
// OR create it like this...
let manager = mdk.media_manager(group_id);

// Encrypt media for upload
let upload = manager.encrypt_for_upload_with_options(
    &image_data,
    "image/jpeg",
    "photo.jpg",
    &MediaProcessingOptions::default()
)?;

// Upload to storage and create reference
let media_ref = MediaReference {
    url: upload_to_storage(&upload.encrypted_data).await?,
    original_hash: upload.original_hash,
    mime_type: upload.mime_type,
    filename: upload.filename,
    dimensions: upload.dimensions,
};

// Later: decrypt media
let decrypted = manager.decrypt_media(&encrypted_data, &media_ref)?;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-gated encrypted media (mip04): per-group media manager for encrypting/decrypting uploads, integrity-checked downloads, metadata extraction/EXIF sanitization, blurhash generation, IMETA/media reference support, and deterministic image upload key derivation and preparation.

* **Documentation**
  * Added Marmot, MLS, and Nostr protocol/reference docs, MLS extensions draft, MCP guidance, and expanded README with usage and examples.

* **Chores**
  * Expanded CI/lint/test matrix, new test/lint targets and helper scripts, and standardized error formatting/conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->